### PR TITLE
feat(mobile): Refactor header stats and implement settings page

### DIFF
--- a/apps/web/app/(main)/settings/page.tsx
+++ b/apps/web/app/(main)/settings/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useTheme } from '@/components/providers/ThemeProvider';
+import styles from './settings.module.css';
+
+export default function SettingsPage() {
+    const { theme, toggleTheme, showExamStats, toggleShowExamStats } = useTheme();
+
+    return (
+        <div className={styles.container}>
+            <h1 className={styles.title}>設定</h1>
+
+            <div className={styles.section}>
+                <h2 className={styles.sectionTitle}>表示・テーマ</h2>
+
+                {/* Dark Mode Toggle */}
+                <div className={styles.row}>
+                    <div>
+                        <div className={styles.label}>ダークモード</div>
+                        <div className={styles.description}>暗いテーマを使用して目の疲れを軽減します。</div>
+                    </div>
+                    <label className={styles.toggleSwitch}>
+                        <input
+                            type="checkbox"
+                            checked={theme === 'dark'}
+                            onChange={toggleTheme}
+                        />
+                        <span className={styles.slider}></span>
+                    </label>
+                </div>
+
+                {/* Exam Stats Toggle */}
+                <div className={styles.row}>
+                    <div>
+                        <div className={styles.label}>演習中の統計表示</div>
+                        <div className={styles.description}>
+                            演習・試験画面のヘッダーに正答率統計を表示します。<br />
+                            オフにしても、ヘッダーの「⚙️」からいつでも確認できます。
+                        </div>
+                    </div>
+                    <label className={styles.toggleSwitch}>
+                        <input
+                            type="checkbox"
+                            checked={showExamStats}
+                            onChange={toggleShowExamStats}
+                        />
+                        <span className={styles.slider}></span>
+                    </label>
+                </div>
+            </div>
+
+            <div className={styles.section}>
+                <h2 className={styles.sectionTitle}>アカウント</h2>
+                <div className={styles.row}>
+                    <div>
+                        <div className={styles.label}>学習データの同期</div>
+                        <div className={styles.description}>現在は自動的にクラウドに同期されています。</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/app/(main)/settings/settings.module.css
+++ b/apps/web/app/(main)/settings/settings.module.css
@@ -1,0 +1,97 @@
+.container {
+    padding: 2rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.title {
+    font-size: 1.8rem;
+    font-weight: 800;
+    margin-bottom: 2rem;
+    color: var(--text-primary);
+}
+
+.section {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.sectionTitle {
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+
+.row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.row:last-child {
+    border-bottom: none;
+}
+
+.label {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.description {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    margin-top: 0.2rem;
+}
+
+.toggleSwitch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 28px;
+}
+
+.toggleSwitch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 34px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked+.slider {
+    background-color: var(--accent-color, #3b82f6);
+}
+
+input:checked+.slider:before {
+    transform: translateX(22px);
+}

--- a/apps/web/components/features/exam/QuestionClient.module.css
+++ b/apps/web/components/features/exam/QuestionClient.module.css
@@ -1,7 +1,9 @@
 .container {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: calc(100dvh - 4rem);
+    /* Subtract PC layout padding (2rem top + 2rem bottom) */
+    /* Better mobile support */
     background-color: var(--bg-primary);
     color: var(--text-primary);
 }
@@ -13,8 +15,16 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0 1.5rem;
+    padding: 0 1rem;
+    /* Reduced padding for mobile */
     flex-shrink: 0;
+}
+
+/* Mobile Helper */
+@media (max-width: 600px) {
+    .mobileHidden {
+        display: none !important;
+    }
 }
 
 .examInfo {
@@ -109,6 +119,11 @@
 }
 
 @media (max-width: 768px) {
+    .container {
+        height: calc(100dvh - 6rem);
+        /* Mobile padding: 5rem top + 1rem bottom */
+    }
+
     .content {
         flex-direction: column;
         overflow-y: auto;
@@ -428,4 +443,97 @@
     cursor: not-allowed;
     background-color: var(--bg-primary);
     color: var(--text-secondary);
+}
+
+/* Header Controls */
+.headerControls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    position: relative;
+    /* For popup positioning */
+}
+
+.statsContainer {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+}
+
+.statItem {
+    background-color: var(--bg-primary);
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    white-space: nowrap;
+}
+
+.settingsBtn {
+    background: transparent;
+    border: none;
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 0.2rem;
+    border-radius: 4px;
+    transition: background 0.2s;
+}
+
+.settingsBtn:hover {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+.settingsPopup {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 0.5rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    padding: 1rem;
+    min-width: 250px;
+    z-index: 1000;
+    color: var(--text-primary);
+}
+
+.popupHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.8rem;
+    font-weight: bold;
+    font-size: 0.9rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.5rem;
+}
+
+.settingRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    cursor: pointer;
+    margin-bottom: 0.5rem;
+    user-select: none;
+}
+
+.popupStats {
+    margin-top: 0.8rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.popupStatRow {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.9rem;
+}
+
+.mobileOnlyStat {
+    display: none;
 }

--- a/apps/web/components/providers/ThemeProvider.tsx
+++ b/apps/web/components/providers/ThemeProvider.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 type Theme = 'light' | 'dark';
 
 interface ThemeContextType {
     theme: Theme;
     toggleTheme: () => void;
+    showExamStats: boolean;
+    toggleShowExamStats: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const [theme, setTheme] = useState<Theme>('light');
+    const [showExamStats, setShowExamStats] = useState(true);
 
     useEffect(() => {
         // Init theme from localStorage or system preference
@@ -24,6 +27,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
             setTheme('dark');
             document.documentElement.setAttribute('data-theme', 'dark');
         }
+
+        // Init stats visibility
+        const savedStats = localStorage.getItem('showExamStats');
+        if (savedStats !== null) {
+            setShowExamStats(savedStats === 'true');
+        }
     }, []);
 
     const toggleTheme = () => {
@@ -33,8 +42,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         document.documentElement.setAttribute('data-theme', newTheme);
     };
 
+    const toggleShowExamStats = () => {
+        const newValue = !showExamStats;
+        setShowExamStats(newValue);
+        localStorage.setItem('showExamStats', String(newValue));
+    };
+
     return (
-        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+        <ThemeContext.Provider value={{ theme, toggleTheme, showExamStats, toggleShowExamStats }}>
             {children}
         </ThemeContext.Provider>
     );

--- a/apps/web/context/SettingsContext.tsx
+++ b/apps/web/context/SettingsContext.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type SettingsContextType = {
+    darkMode: boolean;
+    toggleDarkMode: () => void;
+    showExamStats: boolean;
+    toggleShowExamStats: () => void;
+};
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+    const [darkMode, setDarkMode] = useState(false);
+    const [showExamStats, setShowExamStats] = useState(true);
+
+    // Initialize from localStorage
+    useEffect(() => {
+        const storedTheme = localStorage.getItem('theme');
+        if (storedTheme === 'dark') {
+            setDarkMode(true);
+            document.documentElement.classList.add('dark');
+        }
+
+        const storedStats = localStorage.getItem('showExamStats');
+        if (storedStats !== null) {
+            setShowExamStats(storedStats === 'true');
+        }
+    }, []);
+
+    const toggleDarkMode = () => {
+        setDarkMode((prev) => {
+            const newVal = !prev;
+            if (newVal) {
+                document.documentElement.classList.add('dark');
+                localStorage.setItem('theme', 'dark');
+            } else {
+                document.documentElement.classList.remove('dark');
+                localStorage.setItem('theme', 'light');
+            }
+            return newVal;
+        });
+    };
+
+    const toggleShowExamStats = () => {
+        setShowExamStats((prev) => {
+            const newVal = !prev;
+            localStorage.setItem('showExamStats', String(newVal));
+            return newVal;
+        });
+    };
+
+    return (
+        <SettingsContext.Provider value={{ darkMode, toggleDarkMode, showExamStats, toggleShowExamStats }}>
+            {children}
+        </SettingsContext.Provider>
+    );
+}
+
+export function useSettings() {
+    const context = useContext(SettingsContext);
+    if (!context) {
+        throw new Error('useSettings must be used within a SettingsProvider');
+    }
+    return context;
+}


### PR DESCRIPTION
## Changes
- **Mobile Header**: Refactored to hide detailed stats on mobile and added a settings popup.
- **Settings Page**: Implemented /settings page for Dark Mode and Exam Stats visibility control.
- **Stats Persistence**: Fixed session stats fetching to ensure data persists across navigation.
- **Footer**: Fixed sticky footer layout.

## Verification
- Verified on mobile and desktop views.
- Checked stats persistence and toggle functionality.