### PR TITLE
feat: ゲストモード警告バナーを1問目解答時のみ表示

### DIFF
--- a/apps/web/components/features/exam/QuestionClient.tsx
+++ b/apps/web/components/features/exam/QuestionClient.tsx
@@ -81,6 +81,8 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
     const [isBookmarked, setIsBookmarked] = useState(false);
     // [NEW] Session Flag State
     const [isFlagged, setIsFlagged] = useState(false);
+    // Guest Warning State (show only on first answer)
+    const [showGuestWarning, setShowGuestWarning] = useState(false);
 
     // Load history & progress on mount
     useEffect(() => {
@@ -278,6 +280,11 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
                     statusUpdate: { questionId: qId, isCorrect: (data.result.score || 0) >= 60 }
                 });
             } else {
+                // Guest mode: show warning on first answer only
+                if (!guestManager.hasShownWarning()) {
+                    setShowGuestWarning(true);
+                    guestManager.markWarningShown();
+                }
                 guestManager.saveHistory(record);
             }
 
@@ -338,6 +345,11 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
                 console.error("Failed to save to API", e);
             }
         } else {
+            // Guest mode: show warning on first answer only
+            if (!guestManager.hasShownWarning()) {
+                setShowGuestWarning(true);
+                guestManager.markWarningShown();
+            }
             guestManager.saveHistory(record);
         }
 
@@ -473,10 +485,11 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
                     </div>
                 </header>
 
-                {/* Guest Warning */}
-                {!session?.user && (
-                    <div style={{ background: '#fffbeb', border: '1px solid #fcd34d', color: '#92400e', padding: '0.5rem 1rem', fontSize: '0.85rem', textAlign: 'center' }}>
+                {/* Guest Warning - show only on first answer */}
+                {showGuestWarning && !session?.user && (
+                    <div style={{ background: '#fffbeb', border: '1px solid #fcd34d', color: '#92400e', padding: '0.5rem 1rem', fontSize: '0.85rem', textAlign: 'center', position: 'relative' }}>
                         ⚠️ ゲストモード：履歴はブラウザに保存され、キャッシュクリア等で消失します。<Link href="/login" style={{ textDecoration: 'underline', fontWeight: 'bold' }}>ログイン</Link>してデータを守りましょう。
+                        <button onClick={() => setShowGuestWarning(false)} style={{ position: 'absolute', right: '0.5rem', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem', color: '#92400e' }}>✕</button>
                     </div>
                 )}
 
@@ -660,10 +673,11 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
                 </div>
             </header>
 
-            {/* Guest Warning */}
-            {!session?.user && (
-                <div style={{ background: '#fffbeb', borderBottom: '1px solid #fcd34d', color: '#92400e', padding: '0.5rem 1rem', fontSize: '0.85rem', textAlign: 'center' }}>
-                    ⚠️ ゲストモード：履歴はブラウザに保存され、キャッシュクリア等で消失します。
+            {/* Guest Warning - show only on first answer */}
+            {showGuestWarning && !session?.user && (
+                <div style={{ background: '#fffbeb', borderBottom: '1px solid #fcd34d', color: '#92400e', padding: '0.5rem 1rem', fontSize: '0.85rem', textAlign: 'center', position: 'relative' }}>
+                    ⚠️ ゲストモード：履歴はブラウザに保存され、キャッシュクリア等で消失します。<Link href="/login" style={{ textDecoration: 'underline', fontWeight: 'bold', marginLeft: '0.5rem' }}>ログイン</Link>してデータを守りましょう。
+                    <button onClick={() => setShowGuestWarning(false)} style={{ position: 'absolute', right: '0.5rem', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem', color: '#92400e' }}>✕</button>
                 </div>
             )}
 

--- a/apps/web/lib/guest-manager.ts
+++ b/apps/web/lib/guest-manager.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 const GUEST_ID_KEY = 'ipalab_guest_id';
 const GUEST_HISTORY_KEY = 'ipalab_guest_history';
+const GUEST_WARNING_SHOWN_KEY = 'ipalab_guest_warning_shown';
 
 export const guestManager = {
     getGuestId: (): string => {
@@ -20,6 +21,22 @@ export const guestManager = {
     isGuest: (): boolean => {
         // Needs session context to be accurate, but this handles "no persisted auth" check
         return true; // Simple stub, logic is mostly "if !session"
+    },
+
+    // Guest warning state management
+    hasShownWarning: (): boolean => {
+        if (typeof window === 'undefined') return false;
+        return localStorage.getItem(GUEST_WARNING_SHOWN_KEY) === 'true';
+    },
+
+    markWarningShown: () => {
+        if (typeof window === 'undefined') return;
+        localStorage.setItem(GUEST_WARNING_SHOWN_KEY, 'true');
+    },
+
+    resetWarningFlag: () => {
+        if (typeof window === 'undefined') return;
+        localStorage.removeItem(GUEST_WARNING_SHOWN_KEY);
     },
 
     saveHistory: (history: any) => {
@@ -39,6 +56,7 @@ export const guestManager = {
         if (typeof window === 'undefined') return;
         localStorage.removeItem(GUEST_ID_KEY);
         localStorage.removeItem(GUEST_HISTORY_KEY);
+        localStorage.removeItem(GUEST_WARNING_SHOWN_KEY);
     },
 
     clearHistory: () => {


### PR DESCRIPTION
## 概要
ゲストモードで最初の解答時にのみ警告バナーを表示するように変更

## 変更内容
- **guest-manager.ts**: 警告表示状態の管理機能を追加
  - \hasShownWarning()\: 警告表示済みかを確認
  - \markWarningShown()\: 警告表示済みとして記録
  - \esetWarningFlag()\: 警告フラグをリセット
  - localStorageで状態を永続化 (\ipalab_guest_warning_shown\)

- **QuestionClient.tsx**: バナー表示ロジックを変更
  - \showGuestWarning\ 状態を追加
  - 解答保存時(\saveResult\, \handleSaveAIScore\)に初回のみ警告を表示
  - バナーに閉じるボタン()を追加
  - AM問題PM問題の両方に適用

## 動作
1. ゲストユーザーが初めて解答を保存する
2. 警告バナーが表示される
3. ボタンまたは次の問題への移動でバナーが消える
4. 以降の解答では警告バナーは表示されない
5. ゲストデータをクリアすると警告フラグもリセットされる