### PR TITLE
fix: Application Insights コードレスエージェント無効化と WEBSITES_PORT 修正

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -163,6 +163,21 @@ jobs:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           package: ./deploy
 
+      # Application Insights コードレスエージェント無効化 + WEBSITES_PORT 修正
+      # 背景: コードレスエージェントと手動 preload スクリプトの二重初期化が
+      #       Next.js の canonicalBase エラーを引き起こしていた
+      # 参照: docs/appservice-startup-failure-investigation.md
+      - name: Configure App Service settings
+        run: |
+          az webapp config appsettings set \
+            --name ${{ env.AZURE_WEBAPP_NAME }} \
+            --resource-group rg-pm-exam-dx-prod \
+            --settings \
+              ApplicationInsightsAgent_EXTENSION_VERSION=disabled \
+              XDT_MicrosoftApplicationInsights_Mode=disabled \
+              XDT_MicrosoftApplicationInsights_PreemptSdk=disabled \
+              WEBSITES_PORT=8080
+
       - name: Azure Logout
         run: az logout
 

--- a/docs/01_planning/azure_config/07_ApplicationInsights.md
+++ b/docs/01_planning/azure_config/07_ApplicationInsights.md
@@ -19,3 +19,19 @@
 | **サンプリング** | Adaptive Sampling (有効)              | データ量に応じた調整      |
 | **保持期間**     | 90日                                  | Log Analyticsの設定に依存 |
 | **アラート**     | Server Error > 1%, Response Time > 2s | 異常検知用アラート設定    |
+
+## App Service 統合時の注意事項
+
+**コードレスエージェントの無効化が必須:**
+
+Linux App Service + Node.js + Next.js standalone 構成では、Azure コードレスエージェント
+(`ApplicationInsightsAgent_EXTENSION_VERSION: ~3`) と手動 SDK 初期化 (`appinsights-preload.js`)
+の二重初期化が原因で Next.js がクラッシュする。
+
+以下の設定を必ず `disabled` にすること:
+- `ApplicationInsightsAgent_EXTENSION_VERSION` = `disabled`
+- `XDT_MicrosoftApplicationInsights_Mode` = `disabled`
+- `XDT_MicrosoftApplicationInsights_PreemptSdk` = `disabled`
+
+SDK の初期化は `appinsights-preload.js` (Node.js `--require`) で行い、
+`APPLICATIONINSIGHTS_CONNECTION_STRING` のみを設定する。

--- a/docs/01_planning/azure_config/10_AppService.md
+++ b/docs/01_planning/azure_config/10_AppService.md
@@ -28,5 +28,5 @@
 | リソース名 | `swa-pm-exam-dx-prod` | `app-pm-exam-dx-prod` |
 | SKU | Standard | B1 (Basic) |
 | 月額コスト | ~$9 | ~$13 |
-| Application Insights | 手動 SDK 統合 | コードレス監視 |
+| Application Insights | 手動 SDK 統合 | SDK 手動統合（コードレスエージェント無効） |
 | Node.js 制御 | 制限あり | 完全制御 |

--- a/docs/03_migration/01_Azure_AppService_Design.md
+++ b/docs/03_migration/01_Azure_AppService_Design.md
@@ -44,10 +44,13 @@
 | キー | 値 | 備考 |
 |------|-----|------|
 | `WEBSITE_NODE_DEFAULT_VERSION` | `~20` | Node.js バージョン |
-| `WEBSITES_PORT` | `3000` | Next.js デフォルトポート |
+| `WEBSITES_PORT` | `8080` | Oryx が `PORT=8080` を設定するため合わせる |
 | `NODE_ENV` | `production` | 本番モード |
 | `COSMOS_DB_CONNECTION` | `@Microsoft.KeyVault(...)` | Key Vault 参照 |
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | 自動設定 | コードレス監視で自動 |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | 手動設定 | SDK 手動統合用の接続文字列 |
+| `ApplicationInsightsAgent_EXTENSION_VERSION` | `disabled` | コードレスエージェント無効化 |
+| `XDT_MicrosoftApplicationInsights_Mode` | `disabled` | 自動計測モード無効化 |
+| `XDT_MicrosoftApplicationInsights_PreemptSdk` | `disabled` | SDK 先取り無効化 |
 | `AUTH_SECRET` | `@Microsoft.KeyVault(...)` | Key Vault 参照 |
 | `AUTH_TRUST_HOST` | `true` | NextAuth 設定 |
 | `AUTH_GITHUB_ID` | 設定値 | GitHub OAuth |
@@ -81,9 +84,30 @@ node --require ./appinsights-preload.js server.js
 
 **重要:** Linux App Service + Node.js ではコードレス監視が利用できないため、SDK を手動で初期化する必要があります。
 
+**注意:** Azure のコードレスエージェント (`ApplicationInsightsAgent_EXTENSION_VERSION: ~3`) と
+手動 preload スクリプトを同時に有効にすると、HTTP モジュールの二重パッチにより
+Next.js standalone の内部設定が破壊され、`canonicalBase` エラーでクラッシュします。
+必ずコードレスエージェントを `disabled` に設定してください。
+
+**無効化が必要な設定:**
+| 設定名 | 値 | 理由 |
+|--------|-----|------|
+| `ApplicationInsightsAgent_EXTENSION_VERSION` | `disabled` | コードレスエージェントを無効化 |
+| `XDT_MicrosoftApplicationInsights_Mode` | `disabled` | 自動計測モードを無効化 |
+| `XDT_MicrosoftApplicationInsights_PreemptSdk` | `disabled` | SDK 先取りを無効化 |
+
+**不要な設定（削除推奨）:**
+- `APPINSIGHTS_INSTRUMENTATIONKEY` - コードレスエージェント用（不要）
+- `APPINSIGHTS_CONNECTIONSTRING` - コードレスエージェント用（不要、`APPLICATIONINSIGHTS_CONNECTION_STRING` と重複）
+- `APPINSIGHTS_PROFILERFEATURE_VERSION` - 不要
+- `APPINSIGHTS_SNAPSHOTFEATURE_VERSION` - 不要
+- `DiagnosticServices_EXTENSION_VERSION` - 不要
+- `SnapshotDebugger_EXTENSION_VERSION` - 不要
+
 **対応方法:**
 1. `appinsights-preload.js` でスタートアップ時に SDK を初期化
 2. `--require` オプションで HTTP モジュールより先に読み込み
+3. `instrumentation.ts` がフォールバックとして機能（preload が先に初期化済みの場合はスキップ）
 
 **環境変数の設定:**
 1. Azure Portal > App Service > `app-pm-exam-dx-prod`
@@ -196,8 +220,11 @@ az webapp config appsettings set \
   --resource-group rg-pm-exam-dx-prod \
   --settings \
     NODE_ENV=production \
-    WEBSITES_PORT=3000 \
-    AUTH_TRUST_HOST=true
+    WEBSITES_PORT=8080 \
+    AUTH_TRUST_HOST=true \
+    ApplicationInsightsAgent_EXTENSION_VERSION=disabled \
+    XDT_MicrosoftApplicationInsights_Mode=disabled \
+    XDT_MicrosoftApplicationInsights_PreemptSdk=disabled
 ```
 
 ## 9. Bicep テンプレート
@@ -233,7 +260,10 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
       minTlsVersion: '1.2'
       appSettings: [
         { name: 'NODE_ENV', value: 'production' }
-        { name: 'WEBSITES_PORT', value: '3000' }
+        { name: 'WEBSITES_PORT', value: '8080' }
+        { name: 'ApplicationInsightsAgent_EXTENSION_VERSION', value: 'disabled' }
+        { name: 'XDT_MicrosoftApplicationInsights_Mode', value: 'disabled' }
+        { name: 'XDT_MicrosoftApplicationInsights_PreemptSdk', value: 'disabled' }
       ]
     }
     httpsOnly: true
@@ -259,5 +289,5 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
 ---
 
 **作成日**: 2026-02-04
-**更新日**: 2026-02-04
+**更新日**: 2026-02-06
 **ステータス**: 設計完了


### PR DESCRIPTION
## Summary

- App Service `app-pm-exam-dx-prod` の起動失敗（`canonicalBase` エラーによる無限クラッシュループ）を修正
- 根本原因: Azure Application Insights コードレスエージェント (`~3`) と手動 preload スクリプトの二重初期化が Next.js standalone の内部設定を破壊
- デプロイワークフローに App Service 設定構成ステップを追加し、コードレスエージェントを無効化
- `WEBSITES_PORT` を `3000` から `8080` に修正（Oryx が `PORT=8080` を設定するため）

### 変更内容

| 対策 | 内容 | 変更ファイル |
|------|------|------------|
| 対策1 | コードレスエージェント無効化 | `.github/workflows/azure-app-service.yml` |
| 対策2 | WEBSITES_PORT 不整合修正 | `.github/workflows/azure-app-service.yml` |
| 対策3 | 重複設定の整理（設計書に記載） | 設計書各種 |
| 設計書更新 | 上記の変更を反映 | `docs/` 配下 |

### 参照

- 調査報告書: `docs/appservice-startup-failure-investigation.md`

## Test plan

- [ ] ワークフローの YAML 構文が正しいことを確認
- [ ] デプロイ後に App Service の設定値が正しく反映されていることを `az webapp config appsettings list` で確認
- [ ] App Service が正常に起動し、`canonicalBase` エラーが発生しないことを確認
- [ ] Application Insights にテレメトリデータが送信されていることを確認
- [ ] もし対策1〜3で解消しない場合は、対策4（preload スクリプト除去 + instrumentation.ts 使用）を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)