### PR TITLE
fix: App Service 起動失敗の恒久対策 - CI/CD ワークフロー修正

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -147,27 +147,44 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Deploy to Azure Web App
-        id: deploy-to-webapp
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          package: ./deploy
+      # 起動コマンドを明示的に設定（Oryx デフォルトに依存しない）
+      # 背景: Azure Portal / CLI で設定した startup-file はコードデプロイとは独立して管理される。
+      #       過去に設定された旧起動コマンド (node --require ./appinsights-preload.js server.js) が
+      #       コード変更後も残存し、起動失敗の根本原因となっていた。
+      # 参照: docs/04_reports/AppService_Startup_Failure_RootCause_20260207.md
+      - name: Configure App Service startup command
+        run: |
+          az webapp config set \
+            --name ${{ env.AZURE_WEBAPP_NAME }} \
+            --resource-group rg-pm-exam-dx-prod \
+            --startup-file "node server.js"
 
-      # Application Insights コードレスエージェント無効化 + WEBSITES_PORT 修正
-      # 背景: コードレスエージェントと手動 preload スクリプトの二重初期化が
-      #       Next.js の canonicalBase エラーを引き起こしていた
-      # 参照: docs/appservice-startup-failure-investigation.md
+      # Application Insights コードレスエージェント無効化 + Oryx バイパス
+      # 背景:
+      #   - WEBSITE_RUN_FROM_PACKAGE=1: ZIP パッケージを直接マウントして実行。
+      #     Oryx の node_modules.tar.gz 展開を完全にバイパスし、
+      #     古い依存関係による上書き問題を根本的に排除する。
+      #   - コードレスエージェント無効化: HTTP モンキーパッチによる
+      #     Next.js canonicalBase エラーを防止。
+      # 参照: docs/04_reports/AppService_Startup_Failure_RootCause_20260207.md
       - name: Configure App Service settings
         run: |
           az webapp config appsettings set \
             --name ${{ env.AZURE_WEBAPP_NAME }} \
             --resource-group rg-pm-exam-dx-prod \
             --settings \
+              WEBSITE_RUN_FROM_PACKAGE=1 \
               ApplicationInsightsAgent_EXTENSION_VERSION=disabled \
               XDT_MicrosoftApplicationInsights_Mode=disabled \
               XDT_MicrosoftApplicationInsights_PreemptSdk=disabled \
               WEBSITES_PORT=8080
+
+      - name: Deploy to Azure Web App
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          package: ./deploy
 
       - name: Azure Logout
         run: az logout

--- a/docs/03_migration/01_Azure_AppService_Design.md
+++ b/docs/03_migration/01_Azure_AppService_Design.md
@@ -45,6 +45,7 @@
 |------|-----|------|
 | `WEBSITE_NODE_DEFAULT_VERSION` | `~20` | Node.js バージョン |
 | `WEBSITES_PORT` | `8080` | Oryx が `PORT=8080` を設定するため合わせる |
+| `WEBSITE_RUN_FROM_PACKAGE` | `1` | ZIP パッケージを直接マウントして実行。Oryx の node_modules.tar.gz 展開をバイパスする |
 | `NODE_ENV` | `production` | 本番モード |
 | `COSMOS_DB_CONNECTION` | `@Microsoft.KeyVault(...)` | Key Vault 参照 |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | 手動設定 | SDK 手動統合用の接続文字列 |
@@ -77,6 +78,7 @@ node server.js
 
 ※ Next.js standalone モードの出力ファイル
 ※ Application Insights SDK は `instrumentation.ts`（Next.js Instrumentation Hook）で初期化
+※ **CI/CD ワークフロー内で `az webapp config set --startup-file "node server.js"` を毎回実行し、起動コマンドの乖離を防止する**
 
 ## 4. Application Insights 統合
 
@@ -221,6 +223,7 @@ az webapp config appsettings set \
   --settings \
     NODE_ENV=production \
     WEBSITES_PORT=8080 \
+    WEBSITE_RUN_FROM_PACKAGE=1 \
     AUTH_TRUST_HOST=true \
     ApplicationInsightsAgent_EXTENSION_VERSION=disabled \
     XDT_MicrosoftApplicationInsights_Mode=disabled \
@@ -261,6 +264,7 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
       appSettings: [
         { name: 'NODE_ENV', value: 'production' }
         { name: 'WEBSITES_PORT', value: '8080' }
+        { name: 'WEBSITE_RUN_FROM_PACKAGE', value: '1' }
         { name: 'ApplicationInsightsAgent_EXTENSION_VERSION', value: 'disabled' }
         { name: 'XDT_MicrosoftApplicationInsights_Mode', value: 'disabled' }
         { name: 'XDT_MicrosoftApplicationInsights_PreemptSdk', value: 'disabled' }
@@ -289,5 +293,5 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
 ---
 
 **作成日**: 2026-02-04
-**更新日**: 2026-02-06
+**更新日**: 2026-02-07
 **ステータス**: 設計完了


### PR DESCRIPTION
## 概要

App Service 起動失敗の根本原因分析（docs/04_reports/AppService_Startup_Failure_RootCause_20260207.md）に基づく恒久対策。

## 変更内容

### 対策 B-1: startup-file の設定をワークフローに追加
- `az webapp config set --startup-file "node server.js"` をデプロイステップに追加
- Azure App Service の起動コマンドがコードと乖離する問題を防止

### 対策 B-3: WEBSITE_RUN_FROM_PACKAGE=1 の設定
- ZIP パッケージを直接マウントして実行
- Oryx の node_modules.tar.gz 展開を完全にバイパス
- 古い依存関係による上書き問題を根本的に排除

### デプロイ順序の改善
- 設定（startup-file, appsettings）→ デプロイの順に変更
- デプロイ前に設定が反映されていることを保証

### 設計書の同期更新
- docs/03_migration/01_Azure_AppService_Design.md を更新

## 根本原因（報告書より）
1. Azure App Service の起動コマンドが旧設定のまま（旧 preload スクリプト付き）
2. 旧 node_modules.tar.gz が残存し、古い依存関係（Next.js 15.5.10）で上書き
3. CI/CD ワークフローがこれらの Azure 固有設定を管理していなかった

## 注意事項
- **マージ後、対策 A（手動クリーンアップ）の実行が必要です**
  - Kudu SSH で残存ファイル削除: `rm -f /home/site/wwwroot/node_modules.tar.gz`
  - workflow_dispatch で再デプロイをトリガー
