### PR TITLE
fix: Webpack ビルドでの Application Insights SDK 初期化エラーを修正

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -34,15 +34,19 @@ export async function register() {
     
     try {
         // Application Insights SDK を動的にインポート
-        const appInsights = await import('applicationinsights');
-        
+        // applicationinsights は CommonJS モジュールのため、バンドラによって
+        // import() の返り値の構造が異なる（Webpack: module直接, Turbopack: .default経由）
+        const appInsightsModule = await import('applicationinsights');
+        // CJS モジュールのため Webpack では .default が undefined になる
+        const appInsights = (appInsightsModule.default ?? appInsightsModule) as typeof appInsightsModule;
+
         // SDK が既に初期化されているかチェック
         if (appInsights.defaultClient) {
             console.log('[AppInsights] SDK already initialized, skipping');
             return;
         }
-        
-        appInsights.default
+
+        appInsights
             .setup(connectionString)
             .setAutoCollectRequests(true)           // HTTP リクエストを自動収集
             .setAutoCollectPerformance(true, true)  // パフォーマンスメトリクスを収集
@@ -52,12 +56,13 @@ export async function register() {
             .setAutoCollectPreAggregatedMetrics(true) // 事前集計メトリクス
             .setUseDiskRetryCaching(true)           // 一時的な障害時のディスクキャッシュ
             .setSendLiveMetrics(false)              // Live Metrics は無効（コスト考慮）
-            .setDistributedTracingMode(appInsights.DistributedTracingModes.AI_AND_W3C)
+            .setDistributedTracingMode(appInsightsModule.DistributedTracingModes.AI_AND_W3C)
             .setInternalLogging(false, false)       // 内部ログは無効化
             .start();
 
         // クラウドロール名の設定
-        const client = appInsights.default.defaultClient;
+        const client = appInsights.defaultClient as
+            import('applicationinsights').TelemetryClient | undefined;
         if (client) {
             client.context.tags[client.context.keys.cloudRole] = 'pm-exam-dx-web';
             client.context.tags[client.context.keys.cloudRoleInstance] = process.env.WEBSITE_INSTANCE_ID || 'local';


### PR DESCRIPTION
## Summary
- `applicationinsights` は CJS モジュールのため、Webpack の動的 `import()` では `.default` が `undefined` になる問題を修正
- Turbopack/Webpack 両方に対応する `.default ?? module` フォールバックパターンを適用
- `defaultClient` の TypeScript 型推論が `never` になる問題を型アサーションで解決

## Background
前コミット (`5bfffa4`) で Turbopack の外部モジュールハッシュバグ (vercel/next.js#87737) を回避するため `next build --webpack` に変更したところ、`instrumentation.ts` での `appInsights.default.setup()` 呼び出しが `undefined` エラーで失敗するようになった。

## Test plan
- [ ] Webpack ビルド (`next build --webpack`) が成功すること
- [ ] デプロイ後、ログストリームで `[AppInsights] SDK initialized successfully` が表示されること
- [ ] `[AppInsights] Failed to initialize SDK` エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)