### PR TITLE
fix: Application Insights テレメトリ未送信 - v3 API 移行

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,12 +1,15 @@
 /**
  * Next.js Instrumentation Hook
- * 
+ *
  * Linux App Service では Node.js のコードレス監視（Codeless Monitoring）が
  * 利用できないため、Application Insights SDK を手動で初期化します。
- * 
- * 重要: Application Insights SDK は HTTP モジュールをモンキーパッチするため、
- * 他のモジュールがロードされる前に初期化する必要があります。
- * 
+ *
+ * applicationinsights v3 では内部的に OpenTelemetry を使用しており、
+ * v3 推奨の useAzureMonitor() API を直接使用します。
+ *
+ * 注意: v2 互換の setup().start() API は TelemetryClient.initialize() 内で
+ * エラーを握りつぶすため、初期化失敗を検知できない問題がありました。
+ *
  * @see https://learn.microsoft.com/azure/azure-monitor/app/nodejs
  * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
  */
@@ -14,61 +17,67 @@ export async function register() {
     // Node.js ランタイムでのみ Application Insights を初期化
     // NEXT_RUNTIME が 'nodejs' または undefined の場合にのみ実行（Edge runtime を除外）
     const runtime = process.env.NEXT_RUNTIME;
-    
+
     if (runtime === 'edge') {
-        // Edge runtime では Application Insights SDK は使用不可
         return;
     }
-    
+
     // サーバーサイドでのみ初期化
     if (typeof window !== 'undefined') {
         return;
     }
-    
+
     const connectionString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
-    
+
     if (!connectionString) {
         console.warn('[AppInsights] APPLICATIONINSIGHTS_CONNECTION_STRING not set, telemetry disabled');
         return;
     }
-    
+
     try {
+        // 診断ログレベルを設定（SDK 内部のエラー・警告をログストリームで確認可能にする）
+        if (!process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL) {
+            process.env.APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = 'WARN';
+        }
+
+        // クラウドロール名を OpenTelemetry 環境変数で設定
+        // useAzureMonitor() 呼び出し前に設定する必要がある
+        if (!process.env.OTEL_SERVICE_NAME) {
+            process.env.OTEL_SERVICE_NAME = 'pm-exam-dx-web';
+        }
+        if (!process.env.OTEL_RESOURCE_ATTRIBUTES) {
+            process.env.OTEL_RESOURCE_ATTRIBUTES =
+                `service.instance.id=${process.env.WEBSITE_INSTANCE_ID || 'local'}`;
+        }
+
         // Application Insights SDK を動的にインポート
         // applicationinsights は CommonJS モジュールのため、バンドラによって
         // import() の返り値の構造が異なる（Webpack: module直接, Turbopack: .default経由）
-        const appInsightsModule = await import('applicationinsights');
-        // CJS モジュールのため Webpack では .default が undefined になる
-        const appInsights = (appInsightsModule.default ?? appInsightsModule) as typeof appInsightsModule;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const appInsightsModule = await import('applicationinsights') as any;
+        const appInsights = (appInsightsModule.default ?? appInsightsModule) as typeof import('applicationinsights');
 
-        // SDK が既に初期化されているかチェック
-        if (appInsights.defaultClient) {
-            console.log('[AppInsights] SDK already initialized, skipping');
-            return;
-        }
+        // v3 推奨 API を直接使用
+        // v2 互換の setup().start() は TelemetryClient.initialize() 内で
+        // useAzureMonitor() のエラーを catch して diag.error() にしか出力しないため、
+        // 初期化失敗時も "SDK initialized successfully" と誤表示される問題があった
+        appInsights.useAzureMonitor({
+            azureMonitorExporterOptions: {
+                connectionString,
+            },
+            // console は applicationinsights の InstrumentationOptions に定義されているが、
+            // 型の継承チェーンで DistroInstrumentationOptions として解決されるため型エラーになる
+            instrumentationOptions: {
+                http: { enabled: true },
+                console: { enabled: true },
+                azureSdk: { enabled: true },
+            } as import('applicationinsights').InstrumentationOptions,
+            enableAutoCollectExceptions: true,
+            enableAutoCollectPerformance: true,
+            enableLiveMetrics: false,
+        });
 
-        appInsights
-            .setup(connectionString)
-            .setAutoCollectRequests(true)           // HTTP リクエストを自動収集
-            .setAutoCollectPerformance(true, true)  // パフォーマンスメトリクスを収集
-            .setAutoCollectExceptions(true)         // 未処理例外を収集
-            .setAutoCollectDependencies(true)       // 外部依存関係（DB、HTTP等）を収集
-            .setAutoCollectConsole(true, true)      // console.log/warn/error を収集
-            .setAutoCollectPreAggregatedMetrics(true) // 事前集計メトリクス
-            .setUseDiskRetryCaching(true)           // 一時的な障害時のディスクキャッシュ
-            .setSendLiveMetrics(false)              // Live Metrics は無効（コスト考慮）
-            .setDistributedTracingMode(appInsightsModule.DistributedTracingModes.AI_AND_W3C)
-            .setInternalLogging(false, false)       // 内部ログは無効化
-            .start();
-
-        // クラウドロール名の設定
-        const client = appInsights.defaultClient as
-            import('applicationinsights').TelemetryClient | undefined;
-        if (client) {
-            client.context.tags[client.context.keys.cloudRole] = 'pm-exam-dx-web';
-            client.context.tags[client.context.keys.cloudRoleInstance] = process.env.WEBSITE_INSTANCE_ID || 'local';
-        }
-
-        console.log('[AppInsights] SDK initialized successfully');
+        console.log('[AppInsights] SDK initialized successfully (v3 useAzureMonitor API)');
     } catch (error) {
         console.error('[AppInsights] Failed to initialize SDK:', error);
     }


### PR DESCRIPTION
## Summary

- Application Insights SDK が初期化成功を報告するもテレメトリが一切送信されない問題を修正
- v2 互換 `setup().start()` API から v3 推奨 `useAzureMonitor()` API に移行
- SDK 診断ログを有効化し、クラウドロール名の設定方法を改善

## Root Cause

`applicationinsights` v3.13.0 の v2 互換 API (`setup().start()`) は内部で以下のフローを実行:

1. `setup(cs)` → `TelemetryClient` 作成
2. `.start()` → `TelemetryClient.initialize()` 呼び出し
3. `initialize()` 内で `useAzureMonitor(options)` を呼び出し

**問題**: `initialize()` の try-catch が `useAzureMonitor()` のエラーを握りつぶし、`diag.error()` にしか出力しない。さらに `setInternalLogging(false, false)` で診断ログも無効化されていたため、初期化失敗が完全に隠蔽されていた。

```typescript
// TelemetryClient.initialize() - エラーが握りつぶされる
try {
    useAzureMonitor(this._options);  // ← ここで失敗しても...
} catch (error) {
    diag.error(`Failed to initialize: ${error}`);  // ← これだけ
}
// start() は常に Configuration を返すため、呼び出し元は成功と判断
```

## Changes

| Before | After |
|--------|-------|
| `setup(cs).setAutoCollect*().start()` (v2 shim) | `useAzureMonitor(options)` (v3 direct) |
| `setInternalLogging(false, false)` | `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL=WARN` |
| `client.context.tags[cloudRole]` (初期化後に設定 = 無視される) | `OTEL_SERVICE_NAME` 環境変数 (初期化前に設定) |
| エラー握りつぶし | try-catch で適切にエラー伝播 |

## Test plan

- [ ] PR ビルドが成功することを確認
- [ ] main マージ後、App Service デプロイを確認
- [ ] ログストリームで `[AppInsights] SDK initialized successfully (v3 useAzureMonitor API)` を確認
- [ ] ログストリームで SDK 診断ログ (WARN) にエラーが出ていないことを確認
- [ ] Application Insights (`appi-pm-exam-dx`) の traces / requests にデータが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)