### PR TITLE
fix: Linux App Service コードレスエージェント無効化の修正

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -182,14 +182,28 @@ jobs:
             --resource-group rg-pm-exam-dx-prod \
             --startup-file "node server.js"
 
-      # Application Insights コードレスエージェント無効化 + Oryx バイパス
+      # Application Insights コードレスエージェント（IPA）無効化
       # 背景:
-      #   - WEBSITE_RUN_FROM_PACKAGE=1: ZIP パッケージを直接マウントして実行。
-      #     Oryx の node_modules.tar.gz 展開を完全にバイパスし、
-      #     古い依存関係による上書き問題を根本的に排除する。
-      #   - コードレスエージェント無効化: HTTP モンキーパッチによる
-      #     Next.js canonicalBase エラーを防止。
-      # 参照: docs/04_reports/AppService_Startup_Failure_RootCause_20260207.md
+      #   Linux App Service の IPA エージェントは ApplicationInsightsAgent_EXTENSION_VERSION
+      #   が「存在する」だけで有効化される（値が "disabled" でも無視される）。
+      #   また XDT_* 設定は Windows（IIS）専用で Linux では効果がない。
+      #   これらの設定を削除することで IPA エージェントを確実に無効化し、
+      #   instrumentation.ts の手動 SDK のみがテレメトリを送信するようにする。
+      # 参照: https://learn.microsoft.com/en-us/azure/azure-monitor/app/codeless-app-service
+      - name: Disable codeless agent (delete Linux-incompatible settings)
+        run: |
+          az webapp config appsettings delete \
+            --name ${{ env.AZURE_WEBAPP_NAME }} \
+            --resource-group rg-pm-exam-dx-prod \
+            --setting-names \
+              ApplicationInsightsAgent_EXTENSION_VERSION \
+              XDT_MicrosoftApplicationInsights_Mode \
+              XDT_MicrosoftApplicationInsights_PreemptSdk \
+            2>/dev/null || echo "Settings already removed or not found"
+
+      # Oryx バイパス + ポート設定
+      # WEBSITE_RUN_FROM_PACKAGE=1: ZIP パッケージを直接マウントして実行。
+      # Oryx の node_modules.tar.gz 展開を完全にバイパスする。
       - name: Configure App Service settings
         run: |
           az webapp config appsettings set \
@@ -197,9 +211,6 @@ jobs:
             --resource-group rg-pm-exam-dx-prod \
             --settings \
               WEBSITE_RUN_FROM_PACKAGE=1 \
-              ApplicationInsightsAgent_EXTENSION_VERSION=disabled \
-              XDT_MicrosoftApplicationInsights_Mode=disabled \
-              XDT_MicrosoftApplicationInsights_PreemptSdk=disabled \
               WEBSITES_PORT=8080
 
       - name: Deploy to Azure Web App

--- a/apps/web/e2e/top-to-login.spec.ts
+++ b/apps/web/e2e/top-to-login.spec.ts
@@ -64,7 +64,7 @@ test.describe('トップページ → ログイン フロー', () => {
     test('フッターが表示される', async ({ page }) => {
       await page.goto('/');
 
-      await expect(page.getByText('© 2024 シカクノ')).toBeVisible();
+      await expect(page.getByText('© 2025-2026 シカクノ')).toBeVisible();
     });
   });
 

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,8 +1,9 @@
 /**
- * Next.js Instrumentation Hook - 診断モード
+ * Next.js Instrumentation Hook
  *
- * テレメトリがディスクキャッシュにフォールバックし Application Insights に
- * 到達しない問題を調査。disableOfflineStorage=true で送信エラーを可視化。
+ * Application Insights v3 SDK を useAzureMonitor() API で初期化する。
+ * コードレスエージェント（IPA）は CI/CD で無効化済みのため、
+ * このファイルのみがテレメトリを送信する。
  */
 export async function register() {
     const runtime = process.env.NEXT_RUNTIME;
@@ -16,56 +17,18 @@ export async function register() {
     }
 
     try {
+        // クラウドロール名を OpenTelemetry 環境変数で設定（useAzureMonitor より前に必要）
         if (!process.env.OTEL_SERVICE_NAME) {
             process.env.OTEL_SERVICE_NAME = 'pm-exam-dx-web';
-        }
-
-        // 接続文字列からインジェストエンドポイントを抽出してログ出力
-        const ingestionMatch = connectionString.match(/IngestionEndpoint=([^;]+)/);
-        const ikeyMatch = connectionString.match(/InstrumentationKey=([^;]+)/);
-        console.log('[AppInsights] InstrumentationKey:', ikeyMatch?.[1]?.substring(0, 8) + '...');
-        console.log('[AppInsights] IngestionEndpoint:', ingestionMatch?.[1] || 'NOT FOUND');
-
-        // インジェストエンドポイントへの接続テスト
-        if (ingestionMatch?.[1]) {
-            try {
-                const https = await import('https');
-                const testUrl = ingestionMatch[1].replace(/\/$/, '') + '/v2/track';
-                console.log('[AppInsights] Testing connectivity to:', testUrl);
-                await new Promise<void>((resolve) => {
-                    const req = https.request(testUrl, { method: 'POST', timeout: 5000 }, (res) => {
-                        console.log('[AppInsights] Ingestion endpoint responded:', res.statusCode, res.statusMessage);
-                        resolve();
-                    });
-                    req.on('error', (err: Error) => {
-                        console.error('[AppInsights] Ingestion endpoint UNREACHABLE:', err.message);
-                        resolve();
-                    });
-                    req.on('timeout', () => {
-                        console.error('[AppInsights] Ingestion endpoint TIMEOUT (5s)');
-                        req.destroy();
-                        resolve();
-                    });
-                    req.end('[]');
-                });
-            } catch (testErr) {
-                console.error('[AppInsights] Connectivity test error:', testErr);
-            }
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const appInsightsModule = await import('applicationinsights') as any;
         const appInsights = (appInsightsModule.default ?? appInsightsModule) as typeof import('applicationinsights');
 
-        // useAzureMonitor() 後に DiagConsoleLogger を設定するため先にインポート
-        const otelApi = await import('@opentelemetry/api');
-
-        // disableOfflineStorage=true でディスクフォールバックを無効化
-        // → 送信失敗時にエラーが DiagConsoleLogger に出力される
         appInsights.useAzureMonitor({
             azureMonitorExporterOptions: {
                 connectionString,
-                disableOfflineStorage: true,
             },
             instrumentationOptions: {
                 http: { enabled: true },
@@ -76,16 +39,8 @@ export async function register() {
             enableAutoCollectPerformance: true,
             enableLiveMetrics: false,
         });
-        console.log('[AppInsights] useAzureMonitor() completed (offlineStorage DISABLED)');
 
-        // useAzureMonitor() 後に DiagConsoleLogger を設定（上書き対策）
-        otelApi.diag.setLogger(
-            new otelApi.DiagConsoleLogger(),
-            otelApi.DiagLogLevel.DEBUG,
-        );
-        console.log('[AppInsights] DiagConsoleLogger set (DEBUG level)');
-
-        console.log('[AppInsights] SDK initialized. Waiting for export errors in log stream...');
+        console.log('[AppInsights] SDK initialized (useAzureMonitor v3 API)');
     } catch (error) {
         console.error('[AppInsights] Failed to initialize SDK:', error);
     }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Application Insights のテレメトリが全てディスクキャッシュにフォールバックし、Azure Portal に到達しない問題の根本原因を修正。

### 原因
- **`ApplicationInsightsAgent_EXTENSION_VERSION=disabled`** は Linux App Service では認識されず、設定が「存在する」だけで IPA（In-Process Agent）コードレスエージェントが有効化されていた
- **`XDT_MicrosoftApplicationInsights_*`** 設定は Windows（IIS XML Document Transform）専用で、Linux では一切効果がなかった
- IPA エージェントが `node server.js` 起動前に OpenTelemetry を初期化し、手動 SDK と競合していた

### 修正内容
- **CI/CD**: `az webapp config appsettings delete` で3設定を完全削除（`set disabled` → `delete` に変更）
  - `ApplicationInsightsAgent_EXTENSION_VERSION`
  - `XDT_MicrosoftApplicationInsights_Mode`
  - `XDT_MicrosoftApplicationInsights_PreemptSdk`
- **instrumentation.ts**: 診断コード（接続テスト、DiagConsoleLogger、disableOfflineStorage）を除去し、プロダクション版に整理
- **E2E テスト**: フッターの著作権年を実際の表示に合わせて修正（`© 2024` → `© 2025-2026`）

### 参照
- [Microsoft Docs: Codeless App Service](https://learn.microsoft.com/en-us/azure/azure-monitor/app/codeless-app-service)
- 関連 PR: #92 (v3 API移行), #94 (DEBUG logging), #95 (手動送信テスト), #96 (disableOfflineStorage)

## Test plan
- [ ] デプロイ後、ログストリームで `[AppInsights] SDK initialized (useAzureMonitor v3 API)` が出力されることを確認
- [ ] ログストリームで `IPA Codeless Configuration` のメッセージが出ないことを確認（IPA無効化の検証）
- [ ] Application Insights > traces / requests にテレメトリが表示されることを確認
- [ ] アプリが正常に起動・動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)