### PR TITLE
fix: IPA コードレスエージェントの接続文字列検出を回避

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -182,28 +182,25 @@ jobs:
             --resource-group rg-pm-exam-dx-prod \
             --startup-file "node server.js"
 
-      # Application Insights コードレスエージェント（IPA）無効化
-      # 背景:
-      #   Linux App Service の IPA エージェントは ApplicationInsightsAgent_EXTENSION_VERSION
-      #   が「存在する」だけで有効化される（値が "disabled" でも無視される）。
-      #   また XDT_* 設定は Windows（IIS）専用で Linux では効果がない。
-      #   これらの設定を削除することで IPA エージェントを確実に無効化し、
-      #   instrumentation.ts の手動 SDK のみがテレメトリを送信するようにする。
-      # 参照: https://learn.microsoft.com/en-us/azure/azure-monitor/app/codeless-app-service
-      - name: Disable codeless agent (delete Linux-incompatible settings)
+      # IPA コードレスエージェント無効化
+      # Linux App Service の IPA は APPLICATIONINSIGHTS_CONNECTION_STRING の「存在」を
+      # 検出して自動有効化し、手動 SDK の OpenTelemetry セットアップと競合する。
+      # 対策: 標準の接続文字列を削除し、IPA が認識しないカスタム名 APPINSIGHTS_CS で
+      # 接続文字列を渡す。instrumentation.ts はこのカスタム名から読み取る。
+      - name: Disable IPA codeless agent (remove trigger env vars)
         run: |
           az webapp config appsettings delete \
             --name ${{ env.AZURE_WEBAPP_NAME }} \
             --resource-group rg-pm-exam-dx-prod \
             --setting-names \
+              APPLICATIONINSIGHTS_CONNECTION_STRING \
+              APPINSIGHTS_INSTRUMENTATIONKEY \
               ApplicationInsightsAgent_EXTENSION_VERSION \
               XDT_MicrosoftApplicationInsights_Mode \
               XDT_MicrosoftApplicationInsights_PreemptSdk \
             2>/dev/null || echo "Settings already removed or not found"
 
-      # Oryx バイパス + ポート設定
-      # WEBSITE_RUN_FROM_PACKAGE=1: ZIP パッケージを直接マウントして実行。
-      # Oryx の node_modules.tar.gz 展開を完全にバイパスする。
+      # App Service 設定: Oryx バイパス + ポート + Application Insights 接続文字列
       - name: Configure App Service settings
         run: |
           az webapp config appsettings set \
@@ -211,7 +208,8 @@ jobs:
             --resource-group rg-pm-exam-dx-prod \
             --settings \
               WEBSITE_RUN_FROM_PACKAGE=1 \
-              WEBSITES_PORT=8080
+              WEBSITES_PORT=8080 \
+              APPINSIGHTS_CS="${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}"
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp

--- a/apps/web/app/api/config/telemetry/route.ts
+++ b/apps/web/app/api/config/telemetry/route.ts
@@ -16,30 +16,16 @@ export async function GET() {
     const headersList = await headers();
     const host = headersList.get('host') || 'unknown';
     
-    // 環境変数を取得（SWA では appsettings がランタイムで注入される）
-    const connectionString = process.env.NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING 
-        || process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
+    // 環境変数を取得
+    // APPINSIGHTS_CS: サーバーサイド用カスタム名（IPA コードレスエージェント回避）
+    const connectionString = process.env.NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING
+        || process.env.APPINSIGHTS_CS
         || '';
-    
-    // デバッグ用: 環境変数の状態をログ出力
-    console.log('[telemetry API] host:', host);
-    console.log('[telemetry API] NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING:', 
-        process.env.NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING ? 'SET' : 'NOT SET');
-    console.log('[telemetry API] APPLICATIONINSIGHTS_CONNECTION_STRING:', 
-        process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ? 'SET' : 'NOT SET');
-    
+
     return NextResponse.json({
         connectionString,
-        debug: {
-            host,
-            envVarStatus: {
-                NEXT_PUBLIC: process.env.NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING ? 'SET' : 'NOT SET',
-                STANDARD: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ? 'SET' : 'NOT SET',
-            }
-        }
     }, {
         headers: {
-            // キャッシュなし（デバッグ用）
             'Cache-Control': 'no-store, no-cache, must-revalidate',
         },
     });

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -2,17 +2,20 @@
  * Next.js Instrumentation Hook
  *
  * Application Insights v3 SDK を useAzureMonitor() API で初期化する。
- * コードレスエージェント（IPA）は CI/CD で無効化済みのため、
- * このファイルのみがテレメトリを送信する。
+ *
+ * 重要: 接続文字列は APPINSIGHTS_CS（カスタム名）から読み取る。
+ * Linux App Service の IPA コードレスエージェントは APPLICATIONINSIGHTS_CONNECTION_STRING
+ * の「存在」を検出して自動有効化し、手動 SDK と競合するため、
+ * IPA が認識しない環境変数名を使用している。
  */
 export async function register() {
     const runtime = process.env.NEXT_RUNTIME;
     if (runtime === 'edge') return;
     if (typeof window !== 'undefined') return;
 
-    const connectionString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    const connectionString = process.env.APPINSIGHTS_CS;
     if (!connectionString) {
-        console.warn('[AppInsights] APPLICATIONINSIGHTS_CONNECTION_STRING not set, telemetry disabled');
+        console.warn('[AppInsights] APPINSIGHTS_CS not set, telemetry disabled');
         return;
     }
 


### PR DESCRIPTION
APPLICATIONINSIGHTS_CONNECTION_STRING の「存在」だけで IPA エージェントが 自動有効化される問題を、カスタム環境変数名 APPINSIGHTS_CS で回避する。

- APPLICATIONINSIGHTS_CONNECTION_STRING を App Service から完全削除
- APPINSIGHTS_CS にリネームし instrumentation.ts から読み取り
- telemetry API route のフォールバックも APPINSIGHTS_CS に変更