### PR TITLE
fix: IPA トリガー全設定削除 + TELEMETRY_CONNECTION_STRING に統一

### DIFF
--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -183,10 +183,11 @@ jobs:
             --startup-file "node server.js"
 
       # IPA コードレスエージェント無効化
-      # Linux App Service の IPA は APPLICATIONINSIGHTS_CONNECTION_STRING の「存在」を
-      # 検出して自動有効化し、手動 SDK の OpenTelemetry セットアップと競合する。
-      # 対策: 標準の接続文字列を削除し、IPA が認識しないカスタム名 APPINSIGHTS_CS で
-      # 接続文字列を渡す。instrumentation.ts はこのカスタム名から読み取る。
+      # Linux App Service の IPA は APPLICATIONINSIGHTS_* / APPINSIGHTS_* プレフィックスや
+      # *_EXTENSION_VERSION / XDT_* 設定の「存在」を検出して自動有効化し、
+      # 手動 SDK の OpenTelemetry セットアップと競合する。
+      # 対策: IPA トリガーとなる全設定を削除し、IPA が認識しないカスタム名
+      # TELEMETRY_CONNECTION_STRING で接続文字列を渡す。
       - name: Disable IPA codeless agent (remove trigger env vars)
         run: |
           az webapp config appsettings delete \
@@ -194,13 +195,21 @@ jobs:
             --resource-group rg-pm-exam-dx-prod \
             --setting-names \
               APPLICATIONINSIGHTS_CONNECTION_STRING \
+              APPINSIGHTS_CONNECTIONSTRING \
               APPINSIGHTS_INSTRUMENTATIONKEY \
+              APPINSIGHTS_CS \
+              APPINSIGHTS_PROFILERFEATURE_VERSION \
+              APPINSIGHTS_SNAPSHOTFEATURE_VERSION \
               ApplicationInsightsAgent_EXTENSION_VERSION \
+              DiagnosticServices_EXTENSION_VERSION \
+              InstrumentationEngine_EXTENSION_VERSION \
+              SnapshotDebugger_EXTENSION_VERSION \
               XDT_MicrosoftApplicationInsights_Mode \
               XDT_MicrosoftApplicationInsights_PreemptSdk \
+              XDT_MicrosoftApplicationInsights_BaseExtensions \
             2>/dev/null || echo "Settings already removed or not found"
 
-      # App Service 設定: Oryx バイパス + ポート + Application Insights 接続文字列
+      # App Service 設定: Oryx バイパス + ポート + テレメトリ接続文字列
       - name: Configure App Service settings
         run: |
           az webapp config appsettings set \
@@ -209,7 +218,7 @@ jobs:
             --settings \
               WEBSITE_RUN_FROM_PACKAGE=1 \
               WEBSITES_PORT=8080 \
-              APPINSIGHTS_CS="${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}"
+              TELEMETRY_CONNECTION_STRING="${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}"
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp

--- a/apps/web/app/api/config/telemetry/route.ts
+++ b/apps/web/app/api/config/telemetry/route.ts
@@ -17,9 +17,9 @@ export async function GET() {
     const host = headersList.get('host') || 'unknown';
     
     // 環境変数を取得
-    // APPINSIGHTS_CS: サーバーサイド用カスタム名（IPA コードレスエージェント回避）
+    // TELEMETRY_CONNECTION_STRING: IPA コードレスエージェントが認識しないカスタム名
     const connectionString = process.env.NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING
-        || process.env.APPINSIGHTS_CS
+        || process.env.TELEMETRY_CONNECTION_STRING
         || '';
 
     return NextResponse.json({

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -3,9 +3,10 @@
  *
  * Application Insights v3 SDK を useAzureMonitor() API で初期化する。
  *
- * 重要: 接続文字列は APPINSIGHTS_CS（カスタム名）から読み取る。
- * Linux App Service の IPA コードレスエージェントは APPLICATIONINSIGHTS_CONNECTION_STRING
- * の「存在」を検出して自動有効化し、手動 SDK と競合するため、
+ * 重要: 接続文字列は TELEMETRY_CONNECTION_STRING（カスタム名）から読み取る。
+ * Linux App Service の IPA コードレスエージェントは APPLICATIONINSIGHTS_* や
+ * APPINSIGHTS_* プレフィックスの環境変数を検出して自動有効化し、
+ * 手動 SDK の OpenTelemetry セットアップと競合するため、
  * IPA が認識しない環境変数名を使用している。
  */
 export async function register() {
@@ -13,9 +14,9 @@ export async function register() {
     if (runtime === 'edge') return;
     if (typeof window !== 'undefined') return;
 
-    const connectionString = process.env.APPINSIGHTS_CS;
+    const connectionString = process.env.TELEMETRY_CONNECTION_STRING;
     if (!connectionString) {
-        console.warn('[AppInsights] APPINSIGHTS_CS not set, telemetry disabled');
+        console.warn('[AppInsights] TELEMETRY_CONNECTION_STRING not set, telemetry disabled');
         return;
     }
 


### PR DESCRIPTION
IPA コードレスエージェントは APPINSIGHTS_* プレフィックスも検出するため
APPINSIGHTS_CS でも回避できなかった。

- 環境変数名を TELEMETRY_CONNECTION_STRING に変更（IPA が認識しない名前）
- CI/CD: Portal 起因の残存設定（Profiler, Snapshot, DiagnosticServices 等）も 含めて全 IPA トリガー設定を削除するように拡充
- az cli で手動設定済み（バックアップ: appsettings-backup-20260211.json）