### PR TITLE
fix: APPI認証をAAD(ManagedIdentity)に変更して401エラーを解消

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -3,7 +3,12 @@
  *
  * Application Insights v3 SDK を useAzureMonitor() API で初期化する。
  *
- * 重要: 接続文字列は TELEMETRY_CONNECTION_STRING（カスタム名）から読み取る。
+ * 認証方式: AAD認証（マネージドID）
+ * - APPI リソース `appi-pm-exam-dx` は DisableLocalAuth=true のため、
+ *   Instrumentation Key / 接続文字列だけでは 401 になる。
+ * - ManagedIdentityCredential を使用してテレメトリを送信する。
+ *
+ * 接続文字列: TELEMETRY_CONNECTION_STRING（カスタム名）から読み取る。
  * Linux App Service の IPA コードレスエージェントは APPLICATIONINSIGHTS_* や
  * APPINSIGHTS_* プレフィックスの環境変数を検出して自動有効化し、
  * 手動 SDK の OpenTelemetry セットアップと競合するため、
@@ -30,9 +35,15 @@ export async function register() {
         const appInsightsModule = await import('applicationinsights') as any;
         const appInsights = (appInsightsModule.default ?? appInsightsModule) as typeof import('applicationinsights');
 
+        // AAD認証: ManagedIdentityCredential を使用
+        // APPI リソースの DisableLocalAuth=true に対応
+        const { ManagedIdentityCredential } = await import('@azure/identity');
+        const credential = new ManagedIdentityCredential();
+
         appInsights.useAzureMonitor({
             azureMonitorExporterOptions: {
                 connectionString,
+                credential,
             },
             instrumentationOptions: {
                 http: { enabled: true },
@@ -44,7 +55,7 @@ export async function register() {
             enableLiveMetrics: false,
         });
 
-        console.log('[AppInsights] SDK initialized (useAzureMonitor v3 API)');
+        console.log('[AppInsights] SDK initialized (useAzureMonitor v3 + AAD auth)');
     } catch (error) {
         console.error('[AppInsights] Failed to initialize SDK:', error);
     }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -11,6 +11,7 @@ const nextConfig = {
     // Next.js 15: serverComponentsExternalPackages renamed to serverExternalPackages
     serverExternalPackages: [
         '@azure/cosmos',
+        '@azure/identity',
         // Application Insights v3 SDK + 全依存パッケージ
         // Webpack バンドルによる OpenTelemetry グローバルレジストリ分離を防止
         'applicationinsights',


### PR DESCRIPTION
## 問題

Application Insights (ppi-pm-exam-dx) で `disableLocalAuth: true` が設定されているため、SDK からの Instrumentation Key 認証が **401 Unauthorized** で拒否され、テレメトリが一切記録されていなかった。

## 根本原因

APPI リソースのローカル認証が無効化されており、接続文字列のみでの認証では拒否される。AAD (Entra ID) 認証が必須。

## 対応内容

1. **Managed Identity による AAD 認証を追加** - `instrumentation.ts` で `ManagedIdentityCredential` を使用
2. **`@azure/identity` を serverExternalPackages に追加** - standalone ビルドで `node_modules` に含まれるよう設定
3. **ロール割り当て済み** - App Service の Managed Identity に「Monitoring Metrics Publisher」ロールを付与

## 変更ファイル

- `apps/web/instrumentation.ts`: `ManagedIdentityCredential` による AAD 認証追加
- `apps/web/next.config.js`: `@azure/identity` を `serverExternalPackages` に追加