### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/keisato848/IpaLab/security/code-scanning/27](https://github.com/keisato848/IpaLab/security/code-scanning/27)

In general, to fix this type of problem you add a `permissions` block to either the root of the workflow or to individual jobs, granting only the minimal scopes needed. For a typical CI/test workflow that only checks out code, installs dependencies, runs tests, and uploads artifacts, `contents: read` is usually sufficient; no write scopes are needed.

For this specific workflow (`.github/workflows/playwright.yml`), the simplest, least‑intrusive fix is to add a workflow‑level `permissions` block right after the `name:` line. This will apply to all jobs (here there is a single `test` job) and restrict the `GITHUB_TOKEN` to read access to repository contents. No additional imports, actions, or functionality changes are required; all used actions work fine with read‑only contents. Concretely, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Playwright Tests`) and line 2 (`on:`). No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
