### PR TITLE
fix: reviewモード遷移時の解答・解説復元バグを修正

### DIFF
--- a/apps/web/components/features/exam/QuestionClient.tsx
+++ b/apps/web/components/features/exam/QuestionClient.tsx
@@ -52,8 +52,8 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
 
     // Local state for settings popup
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-    const [selectedOption, setSelectedOption] = useState<string | null>(isReview ? question.correctOption : null);
-    const [showExplanation, setShowExplanation] = useState(isReview);
+    const [selectedOption, setSelectedOption] = useState<string | null>(null);
+    const [showExplanation, setShowExplanation] = useState(false);
     const [startTime, setStartTime] = useState<number>(Date.now());
 
     // Stats State
@@ -206,10 +206,10 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
     };
 
 
-    // Reset state when question changes
+    // Reset state when question changes (reviewモード時は解答・解説を復元)
     useEffect(() => {
-        setSelectedOption(null);
-        setShowExplanation(false);
+        setSelectedOption(isReview ? question.correctOption : null);
+        setShowExplanation(isReview);
         setIsFlagged(false); // Reset Flag
         setStartTime(Date.now());
 
@@ -257,7 +257,7 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
             }
         }
         fetchStats();
-    }, [question.id, question.examId, session]);
+    }, [question.id, question.examId, question.correctOption, isReview, session]);
 
     const formatTime = (seconds: number) => {
         const h = Math.floor(seconds / 3600);


### PR DESCRIPTION
## 概要

ダッシュボードの最近の活動から問題ページに review=true で遷移した際、解答状態と解説が表示されないバグを修正。

## 原因

QuestionClient.tsx に2つのuseEffectが存在し、実行順序の問題で解答復元が上書きされていた。

## 修正

reviewモード用の独立useEffectを削除し、リセットeffect内でisReviewを判定して統合。