### PR TITLE
feat: 問題ページのSEOタイトルを日本語化・西暦併記に改善

### DIFF
--- a/apps/web/__tests__/lib/exam-utils.test.ts
+++ b/apps/web/__tests__/lib/exam-utils.test.ts
@@ -133,4 +133,26 @@ describe('getExamLabel', () => {
             expect(result).toBe('応用情報技術者試験 令和6年 春期');
         });
     });
+
+    describe('西暦併記オプション', () => {
+        it('令和年に西暦を併記する', () => {
+            const result = getExamLabel('AP-2024-Spring-AM', { includeWesternYear: true });
+            expect(result).toBe('応用情報技術者試験 令和6年(2024年) 春期 (午前)');
+        });
+
+        it('平成年に西暦を併記する', () => {
+            const result = getExamLabel('AP-2018-Fall-AM', { includeWesternYear: true });
+            expect(result).toBe('応用情報技術者試験 平成30年(2018年) 秋期 (午前)');
+        });
+
+        it('オプション未指定では西暦を併記しない', () => {
+            const result = getExamLabel('AP-2024-Spring-AM');
+            expect(result).toBe('応用情報技術者試験 令和6年 春期 (午前)');
+        });
+
+        it('午前IIで西暦併記が正しく動作する', () => {
+            const result = getExamLabel('SA-2024-Spring-AM2', { includeWesternYear: true });
+            expect(result).toBe('システムアーキテクト試験 令和6年(2024年) 春期 (午前II)');
+        });
+    });
 });

--- a/apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx
+++ b/apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx
@@ -13,26 +13,28 @@ export const dynamicParams = true;
 export const revalidate = 3600;
 
 import { Metadata } from 'next';
+import { getExamLabel } from '@/lib/exam-utils';
 
 export async function generateMetadata({ params }: { params: Promise<{ year: string; type: string; qNo: string }> }): Promise<Metadata> {
     const { year, type, qNo } = await params;
     const typeSuffix = type === 'AM1' ? 'AM' : type;
     const examId = year.endsWith(`-${typeSuffix}`) ? year : `${year}-${typeSuffix}`;
+    const examLabel = getExamLabel(examId, { includeWesternYear: true });
 
     try {
         const questions = await questionRepository.listByExamId(examId);
         const question = questions.find((q: any) => q.qNo === parseInt(qNo));
 
-        if (!question) return { title: `Not Found - シカクノ` };
+        if (!question) return { title: `Not Found` };
 
-        // Safe substring for description
-        const desc = question.text ? question.text.substring(0, 120).replace(/\n/g, ' ') + '...' : `情報処理技術者試験 ${year} ${type} 問${qNo}`;
+        // 問題文の先頭を概要として使用
+        const desc = question.text ? question.text.substring(0, 120).replace(/\n/g, ' ') + '...' : `${examLabel} 問${qNo}`;
 
         return {
-            title: `Q${qNo} ${year} ${type} - シカクノ`,
+            title: `${examLabel} Q${qNo}`,
             description: desc,
             openGraph: {
-                title: `Q${qNo} ${year} ${type} (正答率: --%) - シカクノ`,
+                title: `${examLabel} Q${qNo} | シカクノ`,
                 description: desc,
             }
         };

--- a/apps/web/lib/exam-utils.ts
+++ b/apps/web/lib/exam-utils.ts
@@ -19,9 +19,10 @@ export function getExamTypeName(code: string): string {
     return examTypeMap[code] || code;
 }
 
-export function getExamLabel(examId: string): string {
+export function getExamLabel(examId: string, options?: { includeWesternYear?: boolean }): string {
     // Format: AP-2024-Spring-AM, FE-2023-Fall-PM
     // Target: 応用情報技術者試験 令和6年 春期 (午前)
+    // With includeWesternYear: 応用情報技術者試験 令和6年(2024年) 春期 (午前)
 
     if (!examId) return '';
 
@@ -40,8 +41,10 @@ export function getExamLabel(examId: string): string {
     let yearLabel = `${year}年`;
     if (year >= 2019) {
         yearLabel = `令和${year - 2018}年`;
+        if (options?.includeWesternYear) yearLabel += `(${year}年)`;
     } else if (year > 1988) {
         yearLabel = `平成${year - 1988}年`;
+        if (options?.includeWesternYear) yearLabel += `(${year}年)`;
     }
 
     // 3. Season


### PR DESCRIPTION
## 概要

問題ページのHTMLタイトルをSEO向けに改善し、検索エンジンからの流入増加を図る。

## 変更内容

### Before
\\\
Q7 SA-2024-Spring-AM2 - シカクノ
\\\

### After
\\\
システムアーキテクト試験 令和6年(2024年) 春期 (午前II) Q7 | シカクノ
\\\

### 変更ファイル

| ファイル | 内容 |
|----------|------|
| apps/web/lib/exam-utils.ts | getExamLabelに includeWesternYear オプション追加。令和/平成に西暦を併記 |
| apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx | generateMetadataでgetExamLabelを使い日本語SEOタイトルを生成 |
| apps/web/__tests__/lib/exam-utils.test.ts | 西暦併記オプションのテスト4件追加 |

## SEO改善ポイント

- 試験名を日本語表記（ユーザーの検索キーワードと一致）
- 和暦＋西暦の併記で検索ヒット率向上
- 午前I/II等の区分も正確に表示
- OGタイトルも同様に改善

## テスト結果

- ユニットテスト: 18ファイル / 281テスト全合格
- E2Eテスト: 60テスト全合格
