### PR TITLE
fix: ズーム時の水平スクロールを有効化（transform→width方式に変更）

### DIFF
--- a/apps/web/components/ui/DiagramViewerModal.module.css
+++ b/apps/web/components/ui/DiagramViewerModal.module.css
@@ -81,9 +81,6 @@
 .zoomContainer {
   flex: 1;
   overflow: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   padding: 24px;
   touch-action: none;
 }

--- a/apps/web/components/ui/DiagramViewerModal.tsx
+++ b/apps/web/components/ui/DiagramViewerModal.tsx
@@ -133,7 +133,11 @@ export default function DiagramViewerModal({ svgHtml, onClose }: DiagramViewerMo
           onTouchEnd={handleTouchEnd}
         >
           <div
-            style={{ transform: `scale(${scale})`, transformOrigin: 'center center', transition: 'transform 0.2s ease', width: '100%' }}
+            style={{
+              width: `${scale * 100}%`,
+              minWidth: 'fit-content',
+              transition: 'width 0.2s ease',
+            }}
             dangerouslySetInnerHTML={{ __html: modalSvgHtml }}
           />
         </div>

--- a/apps/web/e2e/diagram-zoom.spec.ts
+++ b/apps/web/e2e/diagram-zoom.spec.ts
@@ -45,21 +45,20 @@ async function openDiagramModal(page: import('@playwright/test').Page) {
 
 /**
  * zoom-container の現在の scale 値を取得するヘルパー
+ * 内部ラッパーの width スタイル（例: "200%"）からスケール値を算出する
  */
 async function getZoomScale(page: import('@playwright/test').Page): Promise<number> {
-  const transform = await page.getByTestId('diagram-zoom-container').evaluate(
+  const widthStyle = await page.getByTestId('diagram-zoom-container').evaluate(
     (el) => {
-      // transform は内部ラッパー div に適用されている
       const inner = el.firstElementChild as HTMLElement;
-      return inner ? getComputedStyle(inner).transform : getComputedStyle(el).transform;
+      return inner ? inner.style.width : '';
     }
   );
-  // matrix(a, b, c, d, tx, ty) — a が scaleX
-  const match = transform.match(/matrix\(([^,]+)/);
+  // "150%" → 1.5 のように変換
+  const match = widthStyle.match(/([\d.]+)%/);
   if (match) {
-    return parseFloat(match[1]);
+    return parseFloat(match[1]) / 100;
   }
-  // transform: none の場合は scale 1.0
   return 1.0;
 }
 


### PR DESCRIPTION
## 変更概要

DiagramViewerModal のズーム実装を 	ransform: scale() から width: (scale * 100)% 方式に変更し、ズーム時の水平スクロールを有効化しました。

## 問題

- 	ransform: scale() はDOM要素のレイアウトサイズを変更しないため、overflow: auto によるスクロールバーが生成されなかった
- ズームインしても中央部分しか表示できず、周辺部分にアクセスできなかった

## 修正内容

- **DiagramViewerModal.tsx**: 内部ラッパーのスタイルを 	ransform: scale() から width: (scale * 100)% + minWidth: fit-content に変更
- **DiagramViewerModal.module.css**: .zoomContainer からflex中央揃えを削除し、自然なスクロール位置を確保
- **diagram-zoom.spec.ts**: getZoomScale() ヘルパーを style.width パーセント値読み取りに更新

## テスト結果

- ユニットテスト: 281 passed
- E2Eテスト: 60 tests, 58-60 passed（2件のフレーキーテストは今回の変更と無関係）
- Z-01〜Z-11 全テスト合格
- 水平スクロール動作をプログラムで検証済み（scrollWidth > clientWidth, scrollLeft設定成功）