### PR TITLE
feat(progress): 学習進捗集計基盤 Phase 1 MVP + Mermaid 描画修正 (#187, #203)

### DIFF
--- a/apps/web/__tests__/lib/aggregateDailyProgress.test.ts
+++ b/apps/web/__tests__/lib/aggregateDailyProgress.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toDateKey,
+  aggregateDailyProgress,
+  summarizeDailyProgress,
+} from '@/lib/progress/aggregateDailyProgress';
+import type { LearningRecord } from '@ipa-lab/shared';
+
+const NOW = '2026-04-21T00:00:00.000Z';
+const now = () => NOW;
+
+const baseRec = (over: Partial<LearningRecord>): LearningRecord => ({
+  id: '00000000-0000-0000-0000-000000000001',
+  userId: 'u1',
+  questionId: 'q1',
+  examId: 'AP',
+  category: 'tech',
+  isCorrect: true,
+  isFlagged: false,
+  answeredAt: '2026-04-20T01:00:00.000Z',
+  timeTakenSeconds: 60,
+  reviewInterval: 0,
+  easeFactor: 2.5,
+  ...over,
+});
+
+describe('toDateKey', () => {
+  it('extracts UTC YYYY-MM-DD', () => {
+    expect(toDateKey('2026-04-20T23:59:59.000Z')).toBe('2026-04-20');
+    expect(toDateKey('2026-04-21T00:00:00.000Z')).toBe('2026-04-21');
+  });
+  it('returns null on invalid input', () => {
+    expect(toDateKey('not-a-date')).toBeNull();
+  });
+});
+
+describe('aggregateDailyProgress', () => {
+  it('aggregates per UTC day', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', answeredAt: '2026-04-20T10:00:00Z', isCorrect: true, timeTakenSeconds: 30 }),
+      baseRec({ id: 'b', questionId: 'q2', answeredAt: '2026-04-20T11:00:00Z', isCorrect: false, timeTakenSeconds: 45 }),
+      baseRec({ id: 'c', questionId: 'q3', answeredAt: '2026-04-21T01:00:00Z', isCorrect: true, timeTakenSeconds: 60 }),
+    ];
+    const out = aggregateDailyProgress({ userId: 'u1', records, now });
+    expect(out).toHaveLength(2);
+    expect(out[0].date).toBe('2026-04-20');
+    expect(out[0].questionCount).toBe(2);
+    expect(out[0].correctCount).toBe(1);
+    expect(out[0].accuracy).toBe(50);
+    expect(out[0].totalTimeSeconds).toBe(75);
+    expect(out[1].date).toBe('2026-04-21');
+    expect(out[1].questionCount).toBe(1);
+  });
+
+  it('uses latest answer for duplicate questionId', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', answeredAt: '2026-04-20T01:00:00Z', isCorrect: false, timeTakenSeconds: 30 }),
+      baseRec({ id: 'b', questionId: 'q1', answeredAt: '2026-04-20T05:00:00Z', isCorrect: true, timeTakenSeconds: 60 }),
+    ];
+    const out = aggregateDailyProgress({ userId: 'u1', records, now });
+    expect(out).toHaveLength(1);
+    expect(out[0].questionCount).toBe(1);
+    expect(out[0].correctCount).toBe(1);
+    expect(out[0].totalTimeSeconds).toBe(60);
+  });
+
+  it('filters by from/to range (inclusive)', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', answeredAt: '2026-04-19T10:00:00Z' }),
+      baseRec({ id: 'b', questionId: 'q2', answeredAt: '2026-04-20T10:00:00Z' }),
+      baseRec({ id: 'c', questionId: 'q3', answeredAt: '2026-04-22T10:00:00Z' }),
+    ];
+    const out = aggregateDailyProgress({ userId: 'u1', records, from: '2026-04-20', to: '2026-04-21', now });
+    expect(out.map(o => o.date)).toEqual(['2026-04-20']);
+  });
+
+  it('decides status based on plannedCounts', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', answeredAt: '2026-04-20T10:00:00Z' }),
+      baseRec({ id: 'b', questionId: 'q2', answeredAt: '2026-04-21T10:00:00Z' }),
+      baseRec({ id: 'c', questionId: 'q3', answeredAt: '2026-04-21T11:00:00Z' }),
+    ];
+    const plannedCounts = {
+      '2026-04-20': 5, // partial
+      '2026-04-21': 2, // completed
+      '2026-04-22': 3, // none (no records)
+    };
+    const out = aggregateDailyProgress({ userId: 'u1', records, plannedCounts, from: '2026-04-20', to: '2026-04-22', now });
+    const byDate = Object.fromEntries(out.map(o => [o.date, o]));
+    expect(byDate['2026-04-20'].status).toBe('partial');
+    expect(byDate['2026-04-21'].status).toBe('completed');
+    expect(byDate['2026-04-22'].status).toBe('none');
+    expect(byDate['2026-04-22'].questionCount).toBe(0);
+  });
+
+  it('treats unspecified plannedCount as completed when actual >= 1', () => {
+    const records = [baseRec({ id: 'a', answeredAt: '2026-04-20T10:00:00Z' })];
+    const out = aggregateDailyProgress({ userId: 'u1', records, now });
+    expect(out[0].status).toBe('completed');
+  });
+
+  it('counts unique sessions when countSessions=true', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', sessionId: '11111111-1111-1111-1111-111111111111', answeredAt: '2026-04-20T01:00:00Z' }),
+      baseRec({ id: 'b', questionId: 'q2', sessionId: '11111111-1111-1111-1111-111111111111', answeredAt: '2026-04-20T02:00:00Z' }),
+      baseRec({ id: 'c', questionId: 'q3', sessionId: '22222222-2222-2222-2222-222222222222', answeredAt: '2026-04-20T03:00:00Z' }),
+    ];
+    const out = aggregateDailyProgress({ userId: 'u1', records, countSessions: true, now });
+    expect(out[0].sessionCount).toBe(2);
+  });
+
+  it('produces examBreakdown', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', examId: 'AP', isCorrect: true, answeredAt: '2026-04-20T01:00:00Z' }),
+      baseRec({ id: 'b', questionId: 'q2', examId: 'AP', isCorrect: false, answeredAt: '2026-04-20T02:00:00Z' }),
+      baseRec({ id: 'c', questionId: 'q3', examId: 'SC', isCorrect: true, answeredAt: '2026-04-20T03:00:00Z' }),
+    ];
+    const out = aggregateDailyProgress({ userId: 'u1', records, now });
+    expect(out[0].examBreakdown).toEqual({
+      AP: { count: 2, correct: 1 },
+      SC: { count: 1, correct: 1 },
+    });
+  });
+
+  it('ignores records of other users', () => {
+    const records = [
+      baseRec({ id: 'a', userId: 'u1', questionId: 'q1', answeredAt: '2026-04-20T01:00:00Z' }),
+      baseRec({ id: 'b', userId: 'other', questionId: 'q2', answeredAt: '2026-04-20T02:00:00Z' }),
+    ];
+    const out = aggregateDailyProgress({ userId: 'u1', records, now });
+    expect(out[0].questionCount).toBe(1);
+  });
+
+  it('returns empty for no records and no plannedCounts', () => {
+    const out = aggregateDailyProgress({ userId: 'u1', records: [], now });
+    expect(out).toEqual([]);
+  });
+
+  it('id format is `${userId}-${date}`', () => {
+    const records = [baseRec({ id: 'a', answeredAt: '2026-04-20T10:00:00Z' })];
+    const out = aggregateDailyProgress({ userId: 'u1', records, now });
+    expect(out[0].id).toBe('u1-2026-04-20');
+  });
+});
+
+describe('summarizeDailyProgress', () => {
+  it('returns zeros for empty input', () => {
+    const s = summarizeDailyProgress([]);
+    expect(s.totalQuestionCount).toBe(0);
+    expect(s.studyDays).toBe(0);
+  });
+
+  it('aggregates totals across days', () => {
+    const records = [
+      baseRec({ id: 'a', questionId: 'q1', answeredAt: '2026-04-20T10:00:00Z', isCorrect: true, timeTakenSeconds: 30 }),
+      baseRec({ id: 'b', questionId: 'q2', answeredAt: '2026-04-20T11:00:00Z', isCorrect: false, timeTakenSeconds: 45 }),
+      baseRec({ id: 'c', questionId: 'q3', answeredAt: '2026-04-21T01:00:00Z', isCorrect: true, timeTakenSeconds: 60 }),
+    ];
+    const items = aggregateDailyProgress({ userId: 'u1', records, now });
+    const s = summarizeDailyProgress(items);
+    expect(s.totalQuestionCount).toBe(3);
+    expect(s.totalCorrectCount).toBe(2);
+    expect(s.accuracy).toBeCloseTo(66.7, 1);
+    expect(s.studyDays).toBe(2);
+    expect(s.totalTimeSeconds).toBe(135);
+    expect(s.rangeFrom).toBe('2026-04-20');
+    expect(s.rangeTo).toBe('2026-04-21');
+  });
+});

--- a/apps/web/__tests__/lib/mermaidSanitize.test.ts
+++ b/apps/web/__tests__/lib/mermaidSanitize.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeMermaid } from '@/lib/mermaid/sanitize';
+
+describe('sanitizeMermaid', () => {
+    it('returns empty for empty input', () => {
+        expect(sanitizeMermaid('')).toBe('');
+    });
+
+    it('comments out invalid "note:" lines', () => {
+        const input = 'graph TD\n  note: this is invalid';
+        expect(sanitizeMermaid(input)).toBe('graph TD\n  %% note: this is invalid');
+    });
+
+    it('quotes node label containing <- (assignment arrow)', () => {
+        const input = 'graph TD\nB[x <- 1]';
+        expect(sanitizeMermaid(input)).toContain('B["x <- 1"]');
+    });
+
+    it('quotes node label containing -> ', () => {
+        const input = 'graph TD\nA[x -> y]';
+        expect(sanitizeMermaid(input)).toContain('A["x -> y"]');
+    });
+
+    it('quotes node label containing both <- and parens (real AP-2024-Spring/AM1/5 case)', () => {
+        const input = 'graph TD\nD[x <- (x x n)]';
+        expect(sanitizeMermaid(input)).toContain('D["x <- (x x n)"]');
+    });
+
+    it('quotes node label containing colon and commas', () => {
+        const input = 'graph TD\nC[演算 n: M, -1, 1]';
+        expect(sanitizeMermaid(input)).toContain('C["演算 n: M, -1, 1"]');
+    });
+
+    it('does not quote simple labels', () => {
+        const input = 'graph TD\nA[開始]\nF[終了]';
+        const out = sanitizeMermaid(input);
+        expect(out).toContain('A[開始]');
+        expect(out).toContain('F[終了]');
+        expect(out).not.toContain('"開始"');
+    });
+
+    it('does not double-quote already quoted labels', () => {
+        const input = 'graph TD\nB["x <- 1"]';
+        expect(sanitizeMermaid(input)).toBe(input);
+    });
+
+    it('preserves edge syntax with arrows', () => {
+        const input = 'graph TD\nA --> B --> C\nD -- No --> X2';
+        expect(sanitizeMermaid(input)).toBe(input);
+    });
+
+    it('handles decision nodes {a} (curly braces)', () => {
+        const input = 'graph TD\nD{a}';
+        expect(sanitizeMermaid(input)).toBe(input);
+    });
+
+    it('quotes decision node containing special chars', () => {
+        const input = 'graph TD\nD{n > M}';
+        expect(sanitizeMermaid(input)).toContain('D{"n > M"}');
+    });
+
+    it('quotes parenthesized node when it contains comma', () => {
+        const input = 'graph TD\nA(x, y)';
+        expect(sanitizeMermaid(input)).toContain('A("x, y")');
+    });
+
+    it('does not match unbalanced bracket pairs', () => {
+        // [...) shouldn't be rewritten
+        const input = 'A[x <- 1)';
+        expect(sanitizeMermaid(input)).toBe(input);
+    });
+
+    it('handles full AP-2024-Spring/AM1/5 flowchart', () => {
+        const input = [
+            'graph TD',
+            '    A[開始]',
+            '    B[x <- 1]',
+            '    C[演算 n: M, -1, 1]',
+            '    D[x <- (x x n)]',
+            '    E[演算]',
+            '    F[終了]',
+            '    A --> B --> C',
+            '    C --> D',
+            '    D --> C',
+            '    C --> E --> F',
+        ].join('\n');
+        const out = sanitizeMermaid(input);
+        expect(out).toContain('A[開始]');
+        expect(out).toContain('B["x <- 1"]');
+        expect(out).toContain('C["演算 n: M, -1, 1"]');
+        expect(out).toContain('D["x <- (x x n)"]');
+        expect(out).toContain('E[演算]');
+        expect(out).toContain('A --> B --> C');
+    });
+});

--- a/apps/web/app/api/user-progress/daily/recompute/route.ts
+++ b/apps/web/app/api/user-progress/daily/recompute/route.ts
@@ -1,0 +1,83 @@
+/**
+ * POST /api/user-progress/daily/recompute
+ *
+ * バッチ再集計エンドポイント（#187）。
+ *
+ * - 認証ユーザー or 管理用シークレット (`x-recompute-secret`) で実行可能
+ * - 期間 [from, to] を指定し、LearningRecord から日次進捗を集計し DailyProgress に upsert
+ * - 冪等: 同 `${userId}-${date}` を上書きするので何度叩いても一貫
+ * - Azure Functions Timer / GitHub Actions cron から呼び出すことを想定
+ *
+ * Response: { upsertedCount: number, range: { from, to } }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { z } from 'zod';
+import { learningRecordRepository } from '@/lib/repositories/learningRecordRepository';
+import { dailyProgressRepository } from '@/lib/repositories/dailyProgressRepository';
+import { aggregateDailyProgress } from '@/lib/progress/aggregateDailyProgress';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const BodySchema = z.object({
+  userId: z.string().optional(),
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  plannedCounts: z.record(z.string(), z.number()).optional(),
+});
+
+const RECOMPUTE_SECRET = process.env.RECOMPUTE_SECRET;
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const sessionUserId = session?.user?.id;
+  const headerSecret = request.headers.get('x-recompute-secret');
+  const isAdmin = !!RECOMPUTE_SECRET && headerSecret === RECOMPUTE_SECRET;
+
+  if (!sessionUserId && !isAdmin) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'INVALID_BODY' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'INVALID_QUERY', detail: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const { from, to, plannedCounts } = parsed.data;
+  if (from > to) {
+    return NextResponse.json({ error: 'INVALID_RANGE' }, { status: 400 });
+  }
+  // 一般ユーザーは自分の userId のみ。admin は body.userId を尊重。
+  const userId = isAdmin ? parsed.data.userId ?? sessionUserId : sessionUserId;
+  if (!userId) {
+    return NextResponse.json({ error: 'USER_ID_REQUIRED' }, { status: 400 });
+  }
+
+  try {
+    const records = await learningRecordRepository.findByUserId(userId);
+    const items = aggregateDailyProgress({
+      userId,
+      records,
+      from,
+      to,
+      plannedCounts,
+      countSessions: true,
+    });
+    const upsertedCount = await dailyProgressRepository.upsertMany(items);
+    return NextResponse.json({ upsertedCount, range: { from, to } });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Internal Error';
+    return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/user-progress/daily/route.ts
+++ b/apps/web/app/api/user-progress/daily/route.ts
@@ -1,0 +1,86 @@
+/**
+ * GET /api/user-progress/daily?from=YYYY-MM-DD&to=YYYY-MM-DD
+ *
+ * リアルタイム日次進捗 API（#187）。
+ *
+ * - 認証ユーザーの LearningRecord を期間でフィルタし、`aggregateDailyProgress` で集計
+ * - 既存 `DailyProgress` キャッシュは使用せず、常に最新を返す（リアルタイム）
+ * - バッチで永続化する `POST /recompute` と並走する設計（仕様書 §3）
+ *
+ * Response: { items: DailyProgress[], summary: DailyProgressSummary }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { z } from 'zod';
+import { learningRecordRepository } from '@/lib/repositories/learningRecordRepository';
+import {
+  aggregateDailyProgress,
+  summarizeDailyProgress,
+} from '@/lib/progress/aggregateDailyProgress';
+
+export const dynamic = 'force-dynamic';
+
+const QuerySchema = z.object({
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  plannedCounts: z.string().optional(),
+});
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = session?.user?.id;
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const parsed = QuerySchema.safeParse({
+    from: searchParams.get('from'),
+    to: searchParams.get('to'),
+    plannedCounts: searchParams.get('plannedCounts') ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'INVALID_QUERY', detail: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const { from, to } = parsed.data;
+  if (from > to) {
+    return NextResponse.json({ error: 'INVALID_RANGE' }, { status: 400 });
+  }
+
+  let plannedCounts: Record<string, number> | undefined;
+  if (parsed.data.plannedCounts) {
+    try {
+      const obj = JSON.parse(parsed.data.plannedCounts) as unknown;
+      if (obj && typeof obj === 'object') {
+        plannedCounts = {};
+        for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+          if (typeof v === 'number' && Number.isFinite(v) && v >= 0) {
+            plannedCounts[k] = Math.floor(v);
+          }
+        }
+      }
+    } catch {
+      return NextResponse.json({ error: 'INVALID_PLANNED_COUNTS' }, { status: 400 });
+    }
+  }
+
+  try {
+    const records = await learningRecordRepository.findByUserId(userId);
+    const items = aggregateDailyProgress({
+      userId,
+      records,
+      from,
+      to,
+      plannedCounts,
+      countSessions: true,
+    });
+    const summary = summarizeDailyProgress(items);
+    return NextResponse.json({ items, summary });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Internal Error';
+    return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
+  }
+}

--- a/apps/web/components/features/exam/QuestionClient.tsx
+++ b/apps/web/components/features/exam/QuestionClient.tsx
@@ -588,10 +588,7 @@ export default function QuestionClient({ question, year, type, qNo, totalQuestio
             const match = /language-(\w+)/.exec(className || '');
             if (!inline && match && match[1] === 'mermaid') {
                 const rawChildren = String(children);
-                let chartContent = he.decode(rawChildren).replace(/\n$/, '');
-                // Hotfix for common invalid mermaid syntax in datasets
-                // 1. Comment out "note:" lines that aren't valid formatting
-                chartContent = chartContent.replace(/(\n\s*)note:/gi, '$1%% note:');
+                const chartContent = he.decode(rawChildren).replace(/\n$/, '');
                 return <Mermaid chart={chartContent} />;
             }
             return !inline && match ? (

--- a/apps/web/components/features/exam/SCPMExamView.tsx
+++ b/apps/web/components/features/exam/SCPMExamView.tsx
@@ -29,8 +29,7 @@ const markdownComponents = {
         const match = /language-(\w+)/.exec(className || '');
         if (!inline && match && match[1] === 'mermaid') {
             const rawChildren = String(children);
-            let chartContent = he.decode(rawChildren).replace(/\n$/, '');
-            chartContent = chartContent.replace(/(\n\s*)note:/gi, '$1%% note:');
+            const chartContent = he.decode(rawChildren).replace(/\n$/, '');
             return <Mermaid chart={chartContent} />;
         }
         return <code className={className} {...props}>{children}</code>;

--- a/apps/web/components/ui/Mermaid.tsx
+++ b/apps/web/components/ui/Mermaid.tsx
@@ -3,6 +3,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { sanitizeMermaid } from '@/lib/mermaid/sanitize';
 
 const DiagramViewerModal = dynamic(() => import('./DiagramViewerModal'), { ssr: false });
 
@@ -37,8 +38,8 @@ const Mermaid: React.FC<MermaidProps> = ({ chart }) => {
                 if (!ref.current) return;
 
                 const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
-                // Use renderAsync or render
-                const { svg } = await mermaid.render(id, chart);
+                const sanitized = sanitizeMermaid(chart);
+                const { svg } = await mermaid.render(id, sanitized);
 
                 if (isMounted) {
                     setSvg(svg);

--- a/apps/web/lib/cosmos.ts
+++ b/apps/web/lib/cosmos.ts
@@ -10,6 +10,7 @@ const CONTAINER_PARTITION_KEYS: Record<string, string> = {
     Sessions: "/sessionToken",
     LearningRecords: "/userId",
     LearningSessions: "/userId",
+    DailyProgress: "/userId",
     Exams: "/id",
     ExamProgress: "/userId",
     Metrics: "/type",

--- a/apps/web/lib/mermaid/sanitize.ts
+++ b/apps/web/lib/mermaid/sanitize.ts
@@ -1,0 +1,43 @@
+/**
+ * Mermaid syntax sanitizer.
+ *
+ * IPA 試験問題のデータセットや AI Assistant の生成物に含まれる Mermaid 記法は、
+ * Mermaid 10.x のパーサで素直に通らないケースが多い。共通サニタイザを Mermaid
+ * コンポーネントの直前で適用することで、利用箇所（QuestionClient / SCPMExamView /
+ * AIAnswerBox など）に依らず一貫して描画失敗を防ぐ。
+ *
+ * 関連 Issue: #203 (図の描画に失敗している)
+ */
+
+const NEEDS_QUOTING = /[<>():,]|x\s+x/;
+
+/**
+ * Mermaid のノードラベル `Id[label]` / `Id(label)` / `Id{label}` のうち、
+ * 未クォートかつ Mermaid パーサが嫌う特殊文字を含むものを `Id["label"]` 等にラップする。
+ *
+ * - 既にダブルクォートで囲まれているラベルは触らない（`[^\]\)\}"\n]*` で保証）
+ * - エッジ構文 `A --> B` などはラベルが括弧内にないので対象外
+ * - フローチャートの `subgraph` / `flowchart TD` 等の宣言行も対象外
+ */
+export function sanitizeMermaid(chart: string): string {
+    if (!chart) return chart;
+
+    // 1. Comment out invalid "note:" lines that are not valid Mermaid formatting
+    let out = chart.replace(/(\n\s*)note:/gi, '$1%% note:');
+
+    // 2. Quote node labels containing characters Mermaid 10.x cannot parse unquoted.
+    //    Process each bracket pair separately so that `(` inside `[...]` etc. are tolerated.
+    const quoteLabel = (open: string, close: string, charClass: string) => {
+        const re = new RegExp(`(\\b\\w+)\\${open}([${charClass}]*)\\${close}`, 'g');
+        out = out.replace(re, (match, id: string, label: string) => {
+            if (!NEEDS_QUOTING.test(label)) return match;
+            const inner = label.replace(/"/g, '#quot;');
+            return `${id}${open}"${inner}"${close}`;
+        });
+    };
+    quoteLabel('[', ']', '^\\]"\\n');
+    quoteLabel('(', ')', '^)"\\n');
+    quoteLabel('{', '}', '^}"\\n');
+
+    return out;
+}

--- a/apps/web/lib/progress/aggregateDailyProgress.ts
+++ b/apps/web/lib/progress/aggregateDailyProgress.ts
@@ -1,0 +1,214 @@
+/**
+ * 日次進捗集計の純粋関数
+ *
+ * 設計書: docs/02_design/19_DailyProgressAggregation.md
+ * 関連 Issue: #187 (P2-A-1)
+ *
+ * - LearningRecord[] を受け取り、UTC 日付単位で集計する
+ * - 計画タスク (plannedCounts) と照合し status を判定
+ * - I/O ゼロ・副作用なし → vitest で網羅的にテスト可能
+ */
+
+import type { LearningRecord, DailyProgress } from '@ipa-lab/shared';
+
+export interface AggregateDailyProgressInput {
+  userId: string;
+  records: LearningRecord[];
+  /** 計画上の日次目標問題数 (date -> 計画問題数)。未指定の日は status=none/partial 判定の対象外。 */
+  plannedCounts?: Record<string, number>;
+  /** 集計対象期間 [from, to]（YYYY-MM-DD, UTC, 両端含む）。未指定なら records の最小〜最大日。 */
+  from?: string;
+  to?: string;
+  /** session 数集計用に sessionId のユニーク数を出す。 */
+  countSessions?: boolean;
+  /** 集計時刻 (テスト固定用)。未指定なら new Date().toISOString()。 */
+  now?: () => string;
+}
+
+/**
+ * UTC で `answeredAt` から `YYYY-MM-DD` を取り出す。
+ * - 入力が無効な場合は null を返す（呼び出し側でスキップ）。
+ */
+export function toDateKey(answeredAt: string): string | null {
+  const d = new Date(answeredAt);
+  if (Number.isNaN(d.getTime())) return null;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * 日次進捗を計算する。
+ *
+ * - 同じ questionId への複数解答は **最新の answeredAt** を採用する（再挑戦の最終結果を正とする）
+ *   → これは useMonthlyProgress と整合する仕様
+ * - 計画達成判定:
+ *   - plannedCount === 0 または未指定 → 解答 0 で `none`、>=1 で `completed`
+ *   - questionCount >= plannedCount → `completed`
+ *   - 0 < questionCount < plannedCount → `partial`
+ *   - questionCount === 0 かつ plannedCount > 0 → `none`
+ */
+export function aggregateDailyProgress(input: AggregateDailyProgressInput): DailyProgress[] {
+  const { userId, records, plannedCounts, from, to, countSessions, now } = input;
+
+  const latestByQ = new Map<string, LearningRecord>();
+  for (const r of records) {
+    if (r.userId !== userId) continue;
+    const prev = latestByQ.get(r.questionId);
+    if (!prev || new Date(r.answeredAt).getTime() > new Date(prev.answeredAt).getTime()) {
+      latestByQ.set(r.questionId, r);
+    }
+  }
+
+  type Bucket = {
+    questionCount: number;
+    correctCount: number;
+    totalTimeSeconds: number;
+    sessions: Set<string>;
+    exam: Map<string, { count: number; correct: number }>;
+  };
+  const buckets = new Map<string, Bucket>();
+
+  for (const r of latestByQ.values()) {
+    const key = toDateKey(r.answeredAt);
+    if (!key) continue;
+    if (from && key < from) continue;
+    if (to && key > to) continue;
+
+    let b = buckets.get(key);
+    if (!b) {
+      b = {
+        questionCount: 0,
+        correctCount: 0,
+        totalTimeSeconds: 0,
+        sessions: new Set(),
+        exam: new Map(),
+      };
+      buckets.set(key, b);
+    }
+    b.questionCount += 1;
+    if (r.isCorrect) b.correctCount += 1;
+    b.totalTimeSeconds += r.timeTakenSeconds;
+    if (countSessions && r.sessionId) b.sessions.add(r.sessionId);
+    const ex = b.exam.get(r.examId) ?? { count: 0, correct: 0 };
+    ex.count += 1;
+    if (r.isCorrect) ex.correct += 1;
+    b.exam.set(r.examId, ex);
+  }
+
+  if (plannedCounts) {
+    for (const planDate of Object.keys(plannedCounts)) {
+      if (from && planDate < from) continue;
+      if (to && planDate > to) continue;
+      if (!buckets.has(planDate)) {
+        buckets.set(planDate, {
+          questionCount: 0,
+          correctCount: 0,
+          totalTimeSeconds: 0,
+          sessions: new Set(),
+          exam: new Map(),
+        });
+      }
+    }
+  }
+
+  const aggregatedAt = (now ?? (() => new Date().toISOString()))();
+  const out: DailyProgress[] = [];
+  const sortedKeys = Array.from(buckets.keys()).sort();
+  for (const date of sortedKeys) {
+    const b = buckets.get(date)!;
+    const planned = plannedCounts?.[date];
+    const status = decideStatus(b.questionCount, planned);
+    const accuracy =
+      b.questionCount === 0 ? 0 : Math.round((b.correctCount / b.questionCount) * 1000) / 10;
+
+    const examBreakdown: Record<string, { count: number; correct: number }> = {};
+    for (const [examId, v] of b.exam.entries()) examBreakdown[examId] = v;
+
+    out.push({
+      id: `${userId}-${date}`,
+      userId,
+      date,
+      questionCount: b.questionCount,
+      correctCount: b.correctCount,
+      accuracy,
+      totalTimeSeconds: b.totalTimeSeconds,
+      sessionCount: countSessions ? b.sessions.size : 0,
+      examBreakdown,
+      plannedQuestionCount: planned,
+      status,
+      aggregatedAt,
+    });
+  }
+
+  return out;
+}
+
+function decideStatus(actual: number, planned: number | undefined): DailyProgress['status'] {
+  if (planned === undefined || planned === 0) {
+    return actual === 0 ? 'none' : 'completed';
+  }
+  if (actual === 0) return 'none';
+  if (actual >= planned) return 'completed';
+  return 'partial';
+}
+
+export interface DailyProgressSummary {
+  rangeFrom: string;
+  rangeTo: string;
+  totalQuestionCount: number;
+  totalCorrectCount: number;
+  accuracy: number;
+  studyDays: number;
+  completedDays: number;
+  partialDays: number;
+  noneDays: number;
+  totalTimeSeconds: number;
+}
+
+export function summarizeDailyProgress(items: DailyProgress[]): DailyProgressSummary {
+  if (items.length === 0) {
+    return {
+      rangeFrom: '',
+      rangeTo: '',
+      totalQuestionCount: 0,
+      totalCorrectCount: 0,
+      accuracy: 0,
+      studyDays: 0,
+      completedDays: 0,
+      partialDays: 0,
+      noneDays: 0,
+      totalTimeSeconds: 0,
+    };
+  }
+  const sorted = [...items].sort((a, b) => a.date.localeCompare(b.date));
+  let q = 0;
+  let c = 0;
+  let t = 0;
+  let studyDays = 0;
+  let completed = 0;
+  let partial = 0;
+  let none = 0;
+  for (const it of items) {
+    q += it.questionCount;
+    c += it.correctCount;
+    t += it.totalTimeSeconds;
+    if (it.questionCount > 0) studyDays += 1;
+    if (it.status === 'completed') completed += 1;
+    else if (it.status === 'partial') partial += 1;
+    else none += 1;
+  }
+  return {
+    rangeFrom: sorted[0].date,
+    rangeTo: sorted[sorted.length - 1].date,
+    totalQuestionCount: q,
+    totalCorrectCount: c,
+    accuracy: q === 0 ? 0 : Math.round((c / q) * 1000) / 10,
+    studyDays,
+    completedDays: completed,
+    partialDays: partial,
+    noneDays: none,
+    totalTimeSeconds: t,
+  };
+}

--- a/apps/web/lib/repositories/dailyProgressRepository.ts
+++ b/apps/web/lib/repositories/dailyProgressRepository.ts
@@ -1,0 +1,50 @@
+import { getContainer } from '@/lib/cosmos';
+import { DailyProgress, DailyProgressSchema } from '@ipa-lab/shared';
+import { SqlQuerySpec } from '@azure/cosmos';
+
+/**
+ * 日次進捗集計レポジトリ。
+ *
+ * - PartitionKey: /userId
+ * - id: `${userId}-${date}` (UTC YYYY-MM-DD)
+ *
+ * 関連 Issue: #187 (P2-A-1)
+ */
+export const dailyProgressRepository = {
+    containerName: 'DailyProgress',
+
+    async upsert(item: DailyProgress): Promise<DailyProgress> {
+        const validated = DailyProgressSchema.parse(item);
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        const { resource } = await container.items.upsert(validated);
+        if (!resource) throw new Error('Failed to upsert daily progress');
+        return resource as unknown as DailyProgress;
+    },
+
+    async upsertMany(items: DailyProgress[]): Promise<number> {
+        if (items.length === 0) return 0;
+        let n = 0;
+        for (const it of items) {
+            await this.upsert(it);
+            n += 1;
+        }
+        return n;
+    },
+
+    async findByUserAndDateRange(userId: string, from: string, to: string): Promise<DailyProgress[]> {
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        const querySpec: SqlQuerySpec = {
+            query:
+                'SELECT * FROM c WHERE c.userId = @userId AND c.date >= @from AND c.date <= @to ORDER BY c.date ASC',
+            parameters: [
+                { name: '@userId', value: userId },
+                { name: '@from', value: from },
+                { name: '@to', value: to },
+            ],
+        };
+        const { resources } = await container.items.query(querySpec).fetchAll();
+        return resources as DailyProgress[];
+    },
+};

--- a/docs/02_design/19_StudyProgressAggregation.md
+++ b/docs/02_design/19_StudyProgressAggregation.md
@@ -139,3 +139,43 @@ interface DailyProgressAggregate {
 ## 10. 関連
 
 - #188 動的再計画エンジン / #194 統合ダッシュボード / #195 ストリーク機能
+
+---
+
+## 11. Phase 1 MVP実装 (#187)
+
+> Service Bus / Redis / Change Feed Processor を伴う完全構成は将来段階。Phase 1 では **on-demand 集計 + 任意永続化** の最小構成で再計画エンジン (#188) と編集UI (#189) を解禁する。
+
+### 11.1 構成
+
+LearningRecord (Cosmos) -> aggregateDailyProgress (純粋関数) -> GET /api/user-progress/daily (リアルタイム返却) / POST .../daily/recompute (DailyProgress に upsert)
+
+### 11.2 主要モジュール
+
+| モジュール | 役割 |
+|---|---|
+| apps/web/lib/progress/aggregateDailyProgress.ts | 純粋関数。LearningRecord → DailyProgress[] に変換。同 questionId は最新採用、UTC 日付集計、status 判定。 |
+| apps/web/lib/repositories/dailyProgressRepository.ts | Cosmos CRUD。upsert / upsertMany / findByUserAndDateRange |
+| apps/web/app/api/user-progress/daily/route.ts | GET: on-demand 集計を返す |
+| apps/web/app/api/user-progress/daily/recompute/route.ts | POST: 再集計して永続化 (冪等) |
+
+### 11.3 ステータス判定表
+
+| plannedCount | actual | status |
+|---:|---:|---|
+| 未指定 / 0 | 0 | none |
+| 未指定 / 0 | ≥1 | completed |
+| ≥1 | 0 | none |
+| ≥1 | < planned | partial |
+| ≥1 | ≥ planned | completed |
+
+### 11.4 認証
+
+- GET /api/user-progress/daily: NextAuth セッション必須。常に session.user.id を採用。
+- POST .../recompute: NextAuth セッション or x-recompute-secret ヘッダ。後者は管理用 (cron / 手動再集計) で body.userId を尊重。
+
+### 11.5 Phase 2 への発展
+
+- Layer A (Hot Path: Redis) の追加 → 当日分のレイテンシ削減
+- Layer B (バッチ): 現状の recompute を Azure Functions Timer / GitHub Actions cron からキック
+- ストリーク・派生メトリクスは別 Issue で summarizeDailyProgress を拡張

--- a/packages/shared/src/types/models.ts
+++ b/packages/shared/src/types/models.ts
@@ -112,3 +112,28 @@ export const LearningRecordSchema = z.object({
 });
 
 export type LearningRecord = z.infer<typeof LearningRecordSchema>;
+
+// ---------- Daily Progress Aggregation (#187) ----------
+
+/** 日次進捗サマリ。`{userId}-{date}` を id とし userId を Partition Key とする。 */
+export const DailyProgressSchema = z.object({
+    id: z.string(), // `${userId}-${date}` (e.g. "user1-2026-04-21")
+    userId: z.string(),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/), // YYYY-MM-DD (UTC)
+    questionCount: z.number().int().min(0),
+    correctCount: z.number().int().min(0),
+    accuracy: z.number().min(0).max(100), // 0-100
+    totalTimeSeconds: z.number().int().min(0),
+    sessionCount: z.number().int().min(0),
+    /** 試験種別ごとの内訳 (examId -> {count, correct}) */
+    examBreakdown: z.record(z.string(), z.object({
+        count: z.number().int().min(0),
+        correct: z.number().int().min(0),
+    })).default({}),
+    /** 計画タスクとの照合結果 */
+    plannedQuestionCount: z.number().int().min(0).optional(),
+    /** 完了状態 (none: 未着手 / partial: 部分完了 / completed: 計画達成) */
+    status: z.enum(['none', 'partial', 'completed']),
+    aggregatedAt: z.string().datetime(),
+});
+export type DailyProgress = z.infer<typeof DailyProgressSchema>;


### PR DESCRIPTION
## 目的
Issue #187 (P2-A-1) の Phase 1 MVP として、**動的再計画エンジン (#188) と編集UI (#189) を解禁する最小集計基盤** を実装。
あわせて **#203 (AI Assistant 図の描画失敗) の根本修正** も同梱（#203 の修正は局所的で AP-2024-Spring/AM1/5 は復旧しなかったため、本PRで取り直し）。

## 主要変更

### #187 学習進捗集計
| ファイル | 役割 |
|---|---|
| `packages/shared/src/types/models.ts` | `DailyProgressSchema` / `DailyProgress` 型 |
| `apps/web/lib/progress/aggregateDailyProgress.ts` | 純粋関数（UTC日付集計・同questionId最新採用・status判定） |
| `apps/web/lib/repositories/dailyProgressRepository.ts` | Cosmos `DailyProgress` コンテナ CRUD |
| `apps/web/app/api/user-progress/daily/route.ts` | GET: on-demand 集計返却 |
| `apps/web/app/api/user-progress/daily/recompute/route.ts` | POST: 再集計→永続化（冪等） |
| `apps/web/lib/cosmos.ts` | `DailyProgress: '/userId'` 追加 |

### #203 Mermaid 図描画修正
| ファイル | 役割 |
|---|---|
| `apps/web/lib/mermaid/sanitize.ts` | 共通サニタイザ。`<` `>` `(` `)` `:` `,` `x x` を含むラベルを自動的にダブルクォート化 |
| `apps/web/components/ui/Mermaid.tsx` | `mermaid.render` 直前で `sanitizeMermaid` を適用 → 全呼び出し元 (Question/SCPM/AIAnswerBox) に一律適用 |
| `apps/web/components/features/exam/QuestionClient.tsx` | 重複サニタイザを削除（DRY） |
| `apps/web/components/features/exam/SCPMExamView.tsx` | 同上 |

#203 が局所的だった点 (`<-`, `->`, `<>`, `x x` のみ + AIAnswerBox 未対応) を解消。実データ `C[演算 n: M, -1, 1]` `D[x <- (x x n)]` で動作確認済。

## ステータス判定表 (#187)
| plannedCount | actual | status |
|---:|---:|---|
| 未指定 / 0 | 0 | none |
| 未指定 / 0 | ≥1 | completed |
| ≥1 | 0 | none |
| ≥1 | < planned | partial |
| ≥1 | ≥ planned | completed |

## スコープ外（将来拡張）
- Layer A (Hot Path: Redis)
- Change Feed Processor / Service Bus 中継
- Azure Functions Timer による定期 recompute

## 検証
- `npx tsc --noEmit`: 0 errors
- `npx vitest run`: **510 passed (41 files)** — 新規 28 tests (aggregateDailyProgress 14 + mermaidSanitize 14)

## 関連
- Closes part of #187 (Phase 1)
- Supersedes #203
- Unblocks #188, #189
