### PR TITLE
feat(plan): 動的再計画エンジン v1.0 MVP (#188)

### DIFF
--- a/apps/web/__tests__/lib/replan.test.ts
+++ b/apps/web/__tests__/lib/replan.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { replan } from '@/lib/plan/replan';
+import type { StudyPlan } from '@/lib/api';
+import type { DailyProgress } from '@ipa-lab/shared';
+
+const NOW = '2026-04-21T00:00:00.000Z';
+const now = () => NOW;
+
+const dp = (date: string, questionCount: number): DailyProgress => ({
+    id: `u1-${date}`,
+    userId: 'u1',
+    date,
+    questionCount,
+    correctCount: questionCount,
+    accuracy: 100,
+    totalTimeSeconds: 60 * questionCount,
+    sessionCount: 1,
+    examBreakdown: {},
+    status: 'completed',
+    aggregatedAt: NOW,
+});
+
+const buildPlan = (
+    days: { date: string; questionCount: number }[],
+    examDate = '2026-05-01',
+): StudyPlan => ({
+    title: 'test plan',
+    examDate,
+    monthlyGoal: 'goal',
+    weeklySchedule: [
+        {
+            weekNumber: 1,
+            startDate: days[0]?.date ?? '2026-04-15',
+            endDate: days[days.length - 1]?.date ?? '2026-04-30',
+            goal: 'w1',
+            dailyTasks: days.map((d) => ({
+                date: d.date,
+                goal: 'g',
+                questionCount: d.questionCount,
+            })),
+        },
+    ],
+    generatedAt: NOW,
+});
+
+describe('replan', () => {
+    it('no changes when there is no past debt', () => {
+        const plan = buildPlan([
+            { date: '2026-04-21', questionCount: 5 },
+            { date: '2026-04-22', questionCount: 5 },
+        ]);
+        const r = replan({ plan, dailyProgress: [], today: '2026-04-21', options: { now } });
+        expect(r.diff.totalDebtQuestions).toBe(0);
+        expect(r.diff.moved).toEqual([]);
+        expect(r.plan.weeklySchedule[0].dailyTasks[0].questionCount).toBe(5);
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(5);
+    });
+
+    it('redistributes unfulfilled past tasks into future days', () => {
+        const plan = buildPlan([
+            { date: '2026-04-19', questionCount: 10 },
+            { date: '2026-04-20', questionCount: 10 },
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-23', questionCount: 5 },
+        ]);
+        const dailyProgress = [dp('2026-04-19', 4), dp('2026-04-20', 0)];
+        // debt = 6 + 10 = 16
+        const r = replan({ plan, dailyProgress, today: '2026-04-21', options: { now } });
+        expect(r.diff.totalDebtQuestions).toBe(16);
+        // capacity per day: max(baseCap=5, ceil(5*1.5)=8) = 8 → room = 8-5 = 3 per day → 6 total
+        // actually 2 future days * 3 = 6 redistributed; remainder 10 overflows
+        const counts = r.plan.weeklySchedule[0].dailyTasks.map((t) => t.questionCount);
+        // past days unchanged in shape (we don't rewrite past)
+        expect(counts[0]).toBe(10);
+        expect(counts[1]).toBe(10);
+        expect(counts[2]).toBe(8);
+        expect(counts[3]).toBe(8);
+        expect(r.diff.redistributedQuestions).toBe(6);
+        expect(r.diff.overflowed.length).toBeGreaterThan(0);
+        expect(r.warnings.some((w) => w.includes('試験日までに収まらない'))).toBe(true);
+    });
+
+    it('treats partially completed past day correctly', () => {
+        const plan = buildPlan([
+            { date: '2026-04-20', questionCount: 10 },
+            { date: '2026-04-22', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [dp('2026-04-20', 7)],
+            today: '2026-04-21',
+            options: { now },
+        });
+        expect(r.diff.totalDebtQuestions).toBe(3);
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(8);
+        expect(r.diff.redistributedQuestions).toBe(3);
+    });
+
+    it('does not assign tasks beyond examDate', () => {
+        const plan = buildPlan(
+            [
+                { date: '2026-04-19', questionCount: 100 },
+                { date: '2026-04-22', questionCount: 5 },
+                { date: '2026-05-02', questionCount: 5 }, // beyond exam
+            ],
+            '2026-05-01',
+        );
+        const r = replan({
+            plan,
+            dailyProgress: [dp('2026-04-19', 0)],
+            today: '2026-04-21',
+            options: { now },
+        });
+        // future days within examDate: only 2026-04-22, capacity = max(5, ceil(5*1.5)) = 8 → room 3
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(8);
+        expect(r.plan.weeklySchedule[0].dailyTasks[2].questionCount).toBe(5); // unchanged
+        expect(r.diff.overflowed[0].questionCount).toBe(97);
+    });
+
+    it('overflows when there are no future days at all', () => {
+        const plan = buildPlan(
+            [
+                { date: '2026-04-19', questionCount: 10 },
+                { date: '2026-04-20', questionCount: 10 },
+            ],
+            '2026-04-20',
+        );
+        const r = replan({
+            plan,
+            dailyProgress: [dp('2026-04-19', 0), dp('2026-04-20', 0)],
+            today: '2026-04-21',
+            options: { now },
+        });
+        expect(r.diff.totalDebtQuestions).toBe(20);
+        expect(r.diff.redistributedQuestions).toBe(0);
+        expect(r.diff.overflowed.every((o) => o.reason === 'past_exam_date')).toBe(true);
+        expect(r.warnings.some((w) => w.includes('未来日が存在しない'))).toBe(true);
+    });
+
+    it('respects baseCapacity when planned questionCount is 0', () => {
+        const plan = buildPlan([
+            { date: '2026-04-20', questionCount: 5 },
+            { date: '2026-04-22', questionCount: 0 }, // rest day
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [dp('2026-04-20', 0)],
+            today: '2026-04-21',
+            options: { now },
+        });
+        // rest day baseCapacity = 5 → all 5 fit
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(5);
+        expect(r.diff.redistributedQuestions).toBe(5);
+    });
+
+    it('returns immutable copy (does not mutate input)', () => {
+        const plan = buildPlan([
+            { date: '2026-04-20', questionCount: 10 },
+            { date: '2026-04-22', questionCount: 5 },
+        ]);
+        const before = JSON.stringify(plan);
+        replan({ plan, dailyProgress: [dp('2026-04-20', 0)], today: '2026-04-21', options: { now } });
+        expect(JSON.stringify(plan)).toBe(before);
+    });
+
+    it('produces moved entries with carry_forward reason', () => {
+        const plan = buildPlan([
+            { date: '2026-04-20', questionCount: 5 },
+            { date: '2026-04-22', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [dp('2026-04-20', 0)],
+            today: '2026-04-21',
+            options: { now },
+        });
+        expect(r.diff.moved).toHaveLength(1);
+        expect(r.diff.moved[0]).toMatchObject({
+            fromDate: '2026-04-20',
+            toDate: '2026-04-22',
+            reason: 'unfulfilled_carry_forward',
+        });
+    });
+
+    it('completionThreshold < 1 reduces required count', () => {
+        const plan = buildPlan([
+            { date: '2026-04-20', questionCount: 10 },
+            { date: '2026-04-22', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [dp('2026-04-20', 8)],
+            today: '2026-04-21',
+            options: { now, completionThreshold: 0.8 }, // required=8 → debt=0
+        });
+        expect(r.diff.totalDebtQuestions).toBe(0);
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(5);
+    });
+});

--- a/apps/web/app/api/study-plan/replan/route.ts
+++ b/apps/web/app/api/study-plan/replan/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/study-plan/replan
+ *
+ * 動的再計画エンジン v1.0 のエンドポイント (#188)。
+ *
+ * - 認証必須。`session.user.id` を正本とする
+ * - body: `{ plan: StudyPlan, today?: string }`
+ * - サーバ側で当該ユーザーの LearningRecord を読み、`aggregateDailyProgress` で
+ *   過去日の DailyProgress を生成 → `replan(plan, dailyProgress, today)` を実行
+ * - 返却: `{ plan, diff, warnings }`
+ *
+ * クライアント側の plan 編集 (#189) からも、日次バッチ (将来) からも同一エンドポイントを叩ける。
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { z } from 'zod';
+import { learningRecordRepository } from '@/lib/repositories/learningRecordRepository';
+import { aggregateDailyProgress } from '@/lib/progress/aggregateDailyProgress';
+import { replan } from '@/lib/plan/replan';
+import type { StudyPlan } from '@/lib/api';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+const DateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+const StudyPlanShape = z
+    .object({
+        title: z.string(),
+        examDate: DateString,
+        hoursWeekday: z.number().optional(),
+        hoursWeekend: z.number().optional(),
+        monthlyGoal: z.string(),
+        monthlyGoals: z.array(z.unknown()).optional(),
+        weeklySchedule: z.array(
+            z.object({
+                weekNumber: z.number(),
+                startDate: z.string(),
+                endDate: z.string(),
+                theme: z.string().optional(),
+                goal: z.string(),
+                focus: z.string().optional(),
+                dailyTasks: z.array(
+                    z.object({
+                        date: DateString,
+                        missionTitle: z.string().optional(),
+                        goal: z.string(),
+                        questionCount: z.number().int().min(0),
+                        targetCategory: z.string().optional(),
+                        targetExamId: z.string().optional(),
+                        difficulty: z.enum(['easy', 'normal', 'hard']).optional(),
+                        xpReward: z.number().optional(),
+                        isCompleted: z.boolean().optional(),
+                    }),
+                ),
+            }),
+        ),
+        generatedAt: z.string(),
+        totalXpEarned: z.number().optional(),
+    })
+    .passthrough();
+
+const BodySchema = z.object({
+    plan: StudyPlanShape,
+    today: DateString.optional(),
+});
+
+function todayUtc(): string {
+    const d = new Date();
+    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(
+        d.getUTCDate(),
+    ).padStart(2, '0')}`;
+}
+
+export async function POST(request: NextRequest) {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    let body: unknown;
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'INVALID_BODY' }, { status: 400 });
+    }
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+        return NextResponse.json(
+            { error: 'INVALID_INPUT', detail: parsed.error.issues },
+            { status: 400 },
+        );
+    }
+    const plan = parsed.data.plan as unknown as StudyPlan;
+    const today = parsed.data.today ?? todayUtc();
+
+    try {
+        const records = await learningRecordRepository.findByUserId(userId);
+        // 過去日のみ DailyProgress を作る (today の前日まで)
+        const allDates = plan.weeklySchedule.flatMap((w) => w.dailyTasks.map((t) => t.date));
+        const minDate = allDates.length > 0 ? allDates.reduce((a, b) => (a < b ? a : b)) : today;
+        const dailyProgress = aggregateDailyProgress({
+            userId,
+            records,
+            from: minDate,
+            to: today,
+        });
+
+        const result = replan({ plan, dailyProgress, today });
+        return NextResponse.json(result);
+    } catch (e) {
+        const message = e instanceof Error ? e.message : 'Internal Error';
+        return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
+    }
+}

--- a/apps/web/lib/plan/replan.ts
+++ b/apps/web/lib/plan/replan.ts
@@ -1,0 +1,184 @@
+/**
+ * 動的再計画エンジン v1.0 (Phase 1 MVP).
+ *
+ * - 入力: 既存の `StudyPlan` (apps/web/lib/api.ts) + 直近 `DailyProgress` 配列
+ * - 振る舞い: 過去日の未消化問題数 (debt) を、`today` 以降の未来日にグリーディに振り分ける
+ * - 制約: 1 日あたりの上限 = `max(originalQuestionCount, baseCap) * boost`
+ *   （元計画のサイズを大きく超えない範囲で吸収）
+ * - 試験日 (`plan.examDate`) を超える日には絶対に積まない（overflowed として返す）
+ * - 純粋関数。I/O ゼロ。ゴールデンテスト容易。
+ *
+ * 設計書: docs/02_design/20_DynamicReplanningEngine.md §13 (Phase 1 MVP)
+ * 関連 Issue: #188 (P2-A-2)
+ */
+
+import type { StudyPlan } from '@/lib/api';
+import type { DailyProgress } from '@ipa-lab/shared';
+
+export interface ReplanOptions {
+    /** 1日あたり上限ブースト（元計画 questionCount に乗算）。default 1.5 */
+    capacityBoost?: number;
+    /** 元計画 questionCount が 0 の日にも積めるベース容量。default 5 */
+    baseCapacity?: number;
+    /** 過去日の "完了" を判定する際の許容率。actual >= planned * threshold で完了扱い。default 1.0 */
+    completionThreshold?: number;
+    /** 集計時刻 (テスト固定用)。 */
+    now?: () => string;
+}
+
+export interface ReplanMove {
+    fromDate: string;
+    toDate: string;
+    questionCount: number;
+    reason: 'unfulfilled_carry_forward' | 'capacity_overflow_pushed';
+}
+
+export interface ReplanOverflow {
+    fromDate: string;
+    questionCount: number;
+    reason: 'no_future_capacity' | 'past_exam_date';
+}
+
+export interface ReplanDiff {
+    moved: ReplanMove[];
+    overflowed: ReplanOverflow[];
+    totalDebtQuestions: number;
+    redistributedQuestions: number;
+}
+
+export interface ReplanResult {
+    plan: StudyPlan;
+    diff: ReplanDiff;
+    warnings: string[];
+    generatedAt: string;
+    algorithmVersion: '1.0';
+}
+
+export interface ReplanInput {
+    plan: StudyPlan;
+    /** 過去日の進捗（DailyProgress[] のうち date < today のものを参照する） */
+    dailyProgress: DailyProgress[];
+    /** 今日の日付 YYYY-MM-DD (UTC)。 */
+    today: string;
+    options?: ReplanOptions;
+}
+
+const DEFAULT_OPTS: Required<Omit<ReplanOptions, 'now'>> = {
+    capacityBoost: 1.5,
+    baseCapacity: 5,
+    completionThreshold: 1.0,
+};
+
+/**
+ * メインエントリ。`plan` を不変として扱い、再配分後の新しい `StudyPlan` を返す。
+ */
+export function replan(input: ReplanInput): ReplanResult {
+    const opts = { ...DEFAULT_OPTS, ...(input.options ?? {}) };
+    const now = (input.options?.now ?? (() => new Date().toISOString()))();
+    const { plan, dailyProgress, today } = input;
+
+    const progressByDate = new Map<string, DailyProgress>();
+    for (const p of dailyProgress) progressByDate.set(p.date, p);
+
+    // --- 1. 過去日 debt を集計 ----------------------------------------------------
+    let totalDebt = 0;
+    const moved: ReplanMove[] = [];
+    const overflowed: ReplanOverflow[] = [];
+
+    type DayRef = { weekIdx: number; taskIdx: number; date: string; planned: number; cap: number };
+    const futureDays: DayRef[] = [];
+    const pastDebts: { date: string; debt: number }[] = [];
+
+    plan.weeklySchedule.forEach((week, wi) => {
+        week.dailyTasks.forEach((task, ti) => {
+            if (task.date < today) {
+                const actual = progressByDate.get(task.date)?.questionCount ?? 0;
+                const required = Math.ceil(task.questionCount * opts.completionThreshold);
+                const debt = Math.max(0, required - actual);
+                if (debt > 0) {
+                    totalDebt += debt;
+                    pastDebts.push({ date: task.date, debt });
+                }
+            } else if (task.date <= plan.examDate) {
+                const planned = task.questionCount;
+                const cap = Math.max(opts.baseCapacity, Math.ceil(planned * opts.capacityBoost));
+                futureDays.push({ weekIdx: wi, taskIdx: ti, date: task.date, planned, cap });
+            }
+        });
+    });
+
+    futureDays.sort((a, b) => a.date.localeCompare(b.date));
+
+    // --- 2. debt をグリーディに未来日へ詰め込む ---------------------------------------
+    // タスク完了状態 (各 future day の現在割当量)
+    const assigned = new Map<string, number>();
+    for (const d of futureDays) assigned.set(d.date, d.planned);
+
+    let remaining = totalDebt;
+    for (const debt of pastDebts) {
+        let toRedistribute = debt.debt;
+        for (const day of futureDays) {
+            if (toRedistribute === 0) break;
+            const cur = assigned.get(day.date)!;
+            const room = day.cap - cur;
+            if (room <= 0) continue;
+            const take = Math.min(room, toRedistribute);
+            assigned.set(day.date, cur + take);
+            moved.push({
+                fromDate: debt.date,
+                toDate: day.date,
+                questionCount: take,
+                reason: 'unfulfilled_carry_forward',
+            });
+            toRedistribute -= take;
+            remaining -= take;
+        }
+        if (toRedistribute > 0) {
+            overflowed.push({
+                fromDate: debt.date,
+                questionCount: toRedistribute,
+                reason: futureDays.length === 0 ? 'past_exam_date' : 'no_future_capacity',
+            });
+        }
+    }
+
+    // --- 3. 新しい plan を組み立てる ----------------------------------------------
+    const newPlan: StudyPlan = {
+        ...plan,
+        weeklySchedule: plan.weeklySchedule.map((week) => ({
+            ...week,
+            dailyTasks: week.dailyTasks.map((task) => {
+                if (task.date < today) return { ...task };
+                if (task.date > plan.examDate) return { ...task };
+                const newCount = assigned.get(task.date) ?? task.questionCount;
+                if (newCount === task.questionCount) return { ...task };
+                return { ...task, questionCount: newCount };
+            }),
+        })),
+    };
+
+    // --- 4. warnings -----------------------------------------------------------
+    const warnings: string[] = [];
+    if (overflowed.length > 0) {
+        const sumOver = overflowed.reduce((s, o) => s + o.questionCount, 0);
+        warnings.push(
+            `試験日までに収まらない問題が ${sumOver} 問あります。学習時間の見直しを検討してください。`,
+        );
+    }
+    if (totalDebt > 0 && futureDays.length === 0) {
+        warnings.push('未来日が存在しないため、未消化分を再配分できません。試験日以降のタスクを追加してください。');
+    }
+
+    return {
+        plan: newPlan,
+        diff: {
+            moved,
+            overflowed,
+            totalDebtQuestions: totalDebt,
+            redistributedQuestions: totalDebt - remaining,
+        },
+        warnings,
+        generatedAt: now,
+        algorithmVersion: '1.0',
+    };
+}

--- a/docs/02_design/20_DynamicReplanningEngine.md
+++ b/docs/02_design/20_DynamicReplanningEngine.md
@@ -124,3 +124,79 @@ interface ReplanningOutput {
 ## 12. 関連
 
 - #187 進捗集計基盤 / #189 計画編集UI / #191 レコメンドエンジン
+
+---
+
+## 13. Phase 1 MVP実装 (#188)
+
+> 設計書 §1〜§12 のうち、**v1.0 グリーディ + 制約充足** に絞った最小実装。AI を介さない決定論的アルゴリズムで「ユーザー編集にも即時反応」(<1s) を実現する。AI 苦手挿入 (v1.5) や OR-Tools 最適化 (v2.0) は後続で `replan()` を差し替え可能。
+
+### 13.1 構成
+
+```
+[StudyPlan (client localStorage / future Cosmos)]
+                │
+                ▼ POST /api/study-plan/replan { plan, today? }
+[NextAuth session] → userId
+                │
+                ▼
+[learningRecordRepository.findByUserId]
+                │
+                ▼
+[aggregateDailyProgress] → DailyProgress[] (#187)
+                │
+                ▼
+[replan() 純粋関数]
+                │
+                ▼
+[ReplanResult { plan, diff, warnings }]
+```
+
+### 13.2 主要モジュール
+
+| モジュール | 役割 |
+|---|---|
+| `apps/web/lib/plan/replan.ts` | 純粋関数。debt 計算 → 未来日にグリーディ配分 |
+| `apps/web/app/api/study-plan/replan/route.ts` | API エンドポイント。認証 + 集計 + replan |
+
+### 13.3 アルゴリズム (v1.0)
+
+1. **debt 計算**: 過去日 (`date < today`) の各 dailyTask について `required = ceil(planned * completionThreshold)` と `actual = DailyProgress.questionCount` を比較し、`debt = max(0, required - actual)`
+2. **未来日抽出**: `today <= date <= examDate` のみ対象。`date > examDate` は触らない
+3. **キャパシティ**: 各未来日 `cap = max(baseCapacity=5, ceil(planned * capacityBoost=1.5))`
+4. **配分**: pastDebts を日付昇順で走査し、futureDays に対しグリーディに `room = cap - currentAssigned` の範囲で詰める
+5. **オーバーフロー**: 配分しきれない問題は `overflowed` に積み、warning を返す
+
+### 13.4 デフォルトパラメータ
+
+| パラメータ | 値 | 意味 |
+|---|---:|---|
+| `capacityBoost` | 1.5 | 元計画 questionCount を最大 1.5 倍まで膨らませる |
+| `baseCapacity` | 5 | 休息日(planned=0) でも最低 5 問は吸収可能 |
+| `completionThreshold` | 1.0 | 計画通り達成で debt=0 |
+
+### 13.5 API
+
+`POST /api/study-plan/replan`
+
+- 認証: NextAuth セッション必須。`session.user.id` を正本
+- Request body: `{ plan: StudyPlan, today?: "YYYY-MM-DD" }` （today 省略時は UTC 現在日）
+- Response: `{ plan: StudyPlan, diff: ReplanDiff, warnings: string[], generatedAt, algorithmVersion: "1.0" }`
+
+### 13.6 制約充足の保証 (テスト網羅)
+
+- ✅ debt なし → 計画不変
+- ✅ debt あり → 未来日の questionCount が増加
+- ✅ examDate を超える日には絶対に積まない
+- ✅ 未来日が無いと全 debt が overflowed + warning
+- ✅ 休息日 (planned=0) も baseCapacity まで吸収
+- ✅ 入力 plan は不変 (immutable copy)
+- ✅ moved entries に `unfulfilled_carry_forward` reason
+- ✅ completionThreshold で部分達成を許容
+
+### 13.7 Phase 2 への発展
+
+- `pinnedRestDays` / `pinnedFocusDays` をオプション追加
+- 苦手分野 (#191) を `weakAreaInjections` として優先割込み
+- バッチ実行: Azure Functions Timer から全ユーザーに対し `replan` → DB 永続化
+- AI Reasoning: warnings に「なぜこの再配分か」の自然言語説明を付与


### PR DESCRIPTION
Closes #188 (Phase 1 MVP)

## 概要
学習進捗の遅れを未来日へ自動再配分する **決定論的な再計画エンジン v1.0** を実装。
AI を介さず、純粋関数 + DailyProgress (#187) を活用して `<1s` 応答を実現。

## 実装

### 1. `replan()` 純粋関数 — `apps/web/lib/plan/replan.ts`
- **debt 計算**: 過去日について `required = ceil(planned * completionThreshold)`、`debt = max(0, required - actual)`
- **未来日キャパシティ**: `cap = max(baseCapacity=5, ceil(planned * capacityBoost=1.5))`
- **グリーディ配分**: pastDebts を日付順に走査し、未来日の room へ詰める
- **examDate を超えない**: `today <= date <= examDate` のみ対象
- **overflow ハンドリング**: 配分しきれなかった分を `overflowed[]` + `warnings` で返却
- **immutable**: 入力 plan は破壊しない

### 2. API: `POST /api/study-plan/replan`
- NextAuth セッションで `userId` を取得（body の userId は無視）
- LearningRecord → `aggregateDailyProgress` → `replan` の合成
- Zod (`.passthrough()`) で StudyPlan の最低限を検証

### 3. テスト (9 cases, all green)
- no-debt / redistribute / partial / examDate cap / no future days / baseCapacity / immutability / moved reason / completionThreshold

### 4. ドキュメント
`docs/02_design/20_DynamicReplanningEngine.md` に **§13 Phase 1 MVP実装** を追記
（構成図、モジュール表、アルゴリズム、デフォルトパラメータ、API、テスト、Phase 2 展望）

## DoD (#188)
- [x] 再計画ロジック仕様書（§13 として追記）
- [x] ユーザー編集にも即時反応できる純粋関数 IF（編集 UI #189 で配線予定）
- [x] テスト網羅
- [x] `<1s` 応答（決定論アルゴリズム + I/O 最小）

## 検証
- `npx vitest run` → **519 passed (42 files)**
- `npx tsc --noEmit` → **0 errors**

## スコープ外（次フェーズ）
- StudyPlan の Cosmos 永続化 → #189 と合わせて実装
- pinnedRestDays / pinnedFocusDays / 苦手挿入 → v1.5
- monthlyGoals 再計算 → 後続

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>