### PR TITLE
fix(#208): データ未投入時のUX改善とカバレッジ検証スクリプト追加

### DIFF
--- a/.github/prompts/sync-cosmosdb.prompt.md
+++ b/.github/prompts/sync-cosmosdb.prompt.md
@@ -73,6 +73,25 @@ npx tsx packages/data/src/scripts/sync-db.ts
 npx tsx packages/data/src/scripts/sync-db.ts --exam <試験ID>
 ```
 
+### 4.5. 同期結果の検証 (必須)
+
+`sync-db` の実行直後、IP 解放前に **必ず** カバレッジ検証を実行する。
+これは Issue #208 の「ローカル JSON はあるが Cosmos に未投入」のギャップを
+本番投入前に検出するためのガードレール。
+
+```powershell
+npx tsx packages/data/src/scripts/verify-data-coverage.ts
+```
+
+- 終了コード `0`: 全 examId に DB レコードあり (OK)
+- 終了コード `1`: ギャップ検出。問題の examId を確認して `sync-db --exam` で再投入
+- 終了コード `2`: 接続失敗 (IP 許可漏れ等)
+
+特定試験のみ確認する場合:
+```powershell
+npx tsx packages/data/src/scripts/verify-data-coverage.ts --exam SA-2024-Spring-PM1
+```
+
 ### 5. ファイアウォールから IP を削除
 
 同期完了後、追加した IP を必ず削除する。ステップ2で登録済みだった場合も削除する。

--- a/apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx
+++ b/apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx
@@ -50,33 +50,47 @@ export default async function ExamQuestionPage({ params }: { params: Promise<{ y
     const examId = year.endsWith(`-${typeSuffix}`) ? year : `${year}-${typeSuffix}`;
 
     // Fetch Questions
+    // 状態を3種類に区別する:
+    //   - 'ok'              : DB から問題セットを取得できた（その後 qNo 不一致なら本物の Not Found）
+    //   - 'db_error'        : DB アクセスで例外発生（接続/権限/タイムアウト等）
+    //   - 'data_unavailable': DB は応答したが、当該 examId のデータが0件（同期漏れの可能性大）
     let questions: Question[] = [];
+    let loadStatus: 'ok' | 'db_error' | 'data_unavailable' = 'ok';
+    let dbError: unknown = null;
+
     try {
-        // Build Optimization: Use DB directly
         const data = await questionRepository.listByExamId(examId);
         questions = data as unknown as Question[];
+        if (questions.length === 0) {
+            loadStatus = 'data_unavailable';
+            console.warn(`[Page] Cosmos returned 0 questions for examId=${examId}. Possible sync gap.`);
+        }
     } catch (e) {
-        // console.warn(`[Page] Data load failed for ${examId}.`);
+        loadStatus = 'db_error';
+        dbError = e;
+        console.error(`[Page] Cosmos query failed for examId=${examId}:`, e instanceof Error ? e.message : e);
     }
 
-    // Fallback to Filesystem (for local dev without DB)
-    if (questions.length === 0) {
+    // Filesystem フォールバック: ローカル/開発時のみ有効。
+    // 本番(standalone build)では packages/data が同梱されないため事実上動作しない。
+    // 同期漏れを本番で隠蔽しないよう、明示的に開発環境のみ実行する。
+    if (questions.length === 0 && process.env.NODE_ENV !== 'production') {
         try {
             const fsData = await getExamData(examId);
             if (fsData && !Array.isArray(fsData)) {
                 if ('qNo' in fsData) {
-                    // Form B: 単一問題オブジェクト { qNo, theme, context, questions: [{subQNo}] }
                     questions = [fsData] as unknown as Question[];
                 } else if ('questions' in fsData) {
-                    // Form C: ラッパーオブジェクト { questions: [{qNo, theme, context, questions}] }
                     questions = (fsData as any).questions as Question[];
                 }
             } else if (Array.isArray(fsData)) {
-                // Form A: 配列 [{qNo, theme, context, questions}]
                 questions = fsData as unknown as Question[];
             }
+            if (questions.length > 0) {
+                console.info(`[Page] Loaded ${questions.length} questions from filesystem fallback for ${examId} (dev only).`);
+            }
         } catch (e) {
-            console.warn(`[Page] FS Data load failed for ${examId}.`);
+            console.warn(`[Page] FS Data load failed for ${examId}:`, e instanceof Error ? e.message : e);
         }
     }
 
@@ -85,11 +99,28 @@ export default async function ExamQuestionPage({ params }: { params: Promise<{ y
     const question = questions.find(q => q.qNo === qNoInt);
 
     if (!question) {
+        // examId 配下のデータが0件 or DBエラー → "見つからない"ではなく"準備中/障害"として案内
+        const isDataMissing = loadStatus !== 'ok' || questions.length === 0;
+        const heading = isDataMissing
+            ? `この試験のデータが見つかりません`
+            : `問題が見つかりません (Q${qNo})`;
+        const message = isDataMissing
+            ? loadStatus === 'db_error'
+                ? `データ取得時にエラーが発生しました。時間をおいて再度お試しください。問題が継続する場合は管理者にご連絡ください。`
+                : `この試験 (${examId}) の問題データはまだ準備されていません。データ同期が完了していない可能性があります。`
+            : `番号が正しいか確認してください。`;
+
+        // observability: 失敗の根本原因をサーバーログに残す（Application Insights 連携を期待）
+        console.warn(
+            `[Page] Question render failed: examId=${examId}, qNo=${qNo}, status=${loadStatus}, total=${questions.length}` +
+            (dbError instanceof Error ? `, error=${dbError.message}` : '')
+        );
+
         return (
             <div className={styles.container} style={{ justifyContent: 'center', alignItems: 'center' }}>
                 <div style={{ textAlign: 'center' }}>
-                    <h1>問題が見つかりません (Q{qNo})</h1>
-                    <p>番号が正しいか確認してください。</p>
+                    <h1>{heading}</h1>
+                    <p>{message}</p>
                     <Link href={`/exam/${year}/${type}`} style={{ color: '#0070f3', textDecoration: 'underline' }}>
                         問題一覧に戻る
                     </Link>

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -16,6 +16,7 @@
         "sync": "npx ts-node src/syncer/index.ts",
         "sync-db": "npx ts-node src/scripts/sync-db.ts",
         "clean-records": "npx ts-node src/scripts/sync-db.ts clean",
+        "verify-coverage": "npx ts-node src/scripts/verify-data-coverage.ts",
         "cleanse": "ts-node src/scripts/cleanse-pm-data.ts",
         "extract": "ts-node src/scripts/run-extract.ts",
         "fix-cats": "ts-node src/scripts/fix-subcategories.ts",

--- a/packages/data/src/scripts/verify-data-coverage.ts
+++ b/packages/data/src/scripts/verify-data-coverage.ts
@@ -1,0 +1,205 @@
+/**
+ * verify-data-coverage.ts
+ *
+ * 目的:
+ *   ローカルの問題データ (packages/data/data/questions/*) と CosmosDB の Questions
+ *   コンテナを照合し、本番/ステージングへのデータ同期漏れを検出する。
+ *
+ *   Issue #208 のように "ローカルには JSON があるが Cosmos に未投入" のギャップを
+ *   本番投入前に検出することを狙う。
+ *
+ * 使い方:
+ *   1) 接続文字列を環境変数で指定 (apps/web/.env.local の COSMOS_DB_CONNECTION を流用)
+ *   2) `npx tsx packages/data/src/scripts/verify-data-coverage.ts`
+ *      - JSON 出力を希望する場合は `--json` を付与
+ *      - 特定 examId のみ照合する場合は `--exam <examId>`
+ *
+ * 終了コード:
+ *   - 0 : すべての試験が DB に存在し、件数 >= 1
+ *   - 1 : ギャップ検出 (CI/CD で sync-db 後の検証ステップとして利用可)
+ *   - 2 : 設定不備や接続失敗
+ *
+ * 注意:
+ *   CosmosDB は Selected Networks 構成のため、実行元 IP が許可されている必要がある。
+ *   CI/CD からの実行が難しい場合、リリース担当者がローカルで sync-db 直後に
+ *   このスクリプトを手動実行することを想定している。
+ */
+
+import { CosmosClient } from '@azure/cosmos';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as https from 'https';
+
+const possibleEnvPaths = [
+    path.resolve(__dirname, '../../../../apps/web/.env.local'),
+    path.resolve(__dirname, '../../../../apps/web/.env'),
+];
+for (const envPath of possibleEnvPaths) {
+    if (fs.existsSync(envPath)) {
+        dotenv.config({ path: envPath });
+    }
+}
+
+const CONNECTION_STRING = process.env.COSMOS_DB_CONNECTION || process.env.Values_COSMOS_DB_CONNECTION;
+const DATABASE_NAME = process.env.COSMOS_DB_NAME || 'pm-exam-dx-db';
+const QUESTIONS_CONTAINER = 'Questions';
+
+const QUESTIONS_DIR = path.resolve(__dirname, '../../data/questions');
+
+interface CoverageRow {
+    examId: string;
+    localExists: boolean;
+    localQuestionCount: number;
+    dbQuestionCount: number;
+    status: 'ok' | 'missing_in_db' | 'count_mismatch' | 'extra_in_db' | 'local_only' | 'db_only';
+    note?: string;
+}
+
+function listLocalExamIds(): string[] {
+    if (!fs.existsSync(QUESTIONS_DIR)) {
+        console.error(`[verify] Local questions dir not found: ${QUESTIONS_DIR}`);
+        return [];
+    }
+    return fs
+        .readdirSync(QUESTIONS_DIR, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name)
+        .sort();
+}
+
+function countLocalQuestions(examId: string): number {
+    const dir = path.join(QUESTIONS_DIR, examId);
+    const transformed = path.join(dir, 'questions_transformed.json');
+    const raw = path.join(dir, 'questions_raw.json');
+    const file = fs.existsSync(transformed) ? transformed : fs.existsSync(raw) ? raw : null;
+    if (!file) return 0;
+    try {
+        const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        if (Array.isArray(data)) return data.length;
+        if (data && Array.isArray(data.questions)) return data.questions.length;
+        // 単一大問オブジェクト形式 (qNo を持つ)
+        if (data && typeof data === 'object' && 'qNo' in data) return 1;
+        return 0;
+    } catch (e) {
+        console.warn(`[verify] Failed to parse ${file}: ${(e as Error).message}`);
+        return 0;
+    }
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const jsonOutput = args.includes('--json');
+    const examFilterIdx = args.indexOf('--exam');
+    const examFilter = examFilterIdx >= 0 ? args[examFilterIdx + 1] : null;
+
+    if (!CONNECTION_STRING) {
+        console.error('[verify] COSMOS_DB_CONNECTION is not set. Provide via apps/web/.env.local or env var.');
+        process.exit(2);
+    }
+
+    const isLocal = CONNECTION_STRING.includes('localhost') || CONNECTION_STRING.includes('127.0.0.1');
+    const clientOptions: any = { connectionString: CONNECTION_STRING };
+    if (isLocal) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+        clientOptions.agent = new https.Agent({ rejectUnauthorized: false });
+    }
+
+    const client = new CosmosClient(clientOptions);
+    const container = client.database(DATABASE_NAME).container(QUESTIONS_CONTAINER);
+
+    // 1) DB 側: examId ごとの件数を集計
+    const dbCounts = new Map<string, number>();
+    try {
+        const { resources } = await container.items
+            .query<{ examId: string; total: number }>(
+                'SELECT c.examId, COUNT(1) AS total FROM c GROUP BY c.examId'
+            )
+            .fetchAll();
+        for (const row of resources) {
+            dbCounts.set(row.examId, Number(row.total) || 0);
+        }
+    } catch (e) {
+        console.error(`[verify] Cosmos query failed: ${(e as Error).message}`);
+        process.exit(2);
+    }
+
+    // 2) ローカル側: 各 examId の件数を算出
+    const localExamIds = listLocalExamIds();
+    const allExamIds = new Set<string>([...localExamIds, ...dbCounts.keys()]);
+    const targets = examFilter ? [examFilter] : Array.from(allExamIds).sort();
+
+    const rows: CoverageRow[] = targets.map((examId) => {
+        const localExists = localExamIds.includes(examId);
+        const localCount = localExists ? countLocalQuestions(examId) : 0;
+        const dbCount = dbCounts.get(examId) ?? 0;
+
+        let status: CoverageRow['status'] = 'ok';
+        let note: string | undefined;
+
+        if (localExists && dbCount === 0) {
+            status = 'missing_in_db';
+            note = 'Local data exists but DB has 0 records. Run sync-db.';
+        } else if (!localExists && dbCount > 0) {
+            status = 'db_only';
+            note = 'DB has records but no local data dir. Possibly orphaned.';
+        } else if (localExists && localCount > 0 && dbCount > 0 && localCount !== dbCount) {
+            // 大問数の不一致は階層化 (Hierarchical) の差異の可能性もあるため warn 扱い
+            status = 'count_mismatch';
+            note = `local=${localCount} vs db=${dbCount}`;
+        } else if (localExists && localCount === 0) {
+            status = 'local_only';
+            note = 'Local dir found but JSON is empty/unreadable.';
+        }
+
+        return {
+            examId,
+            localExists,
+            localQuestionCount: localCount,
+            dbQuestionCount: dbCount,
+            status,
+            note,
+        };
+    });
+
+    const problems = rows.filter((r) => r.status !== 'ok');
+
+    if (jsonOutput) {
+        console.log(JSON.stringify({ database: DATABASE_NAME, total: rows.length, problems: problems.length, rows }, null, 2));
+    } else {
+        console.log(`\n=== Data Coverage Report ===`);
+        console.log(`Database: ${DATABASE_NAME}`);
+        console.log(`Inspected: ${rows.length} examId(s) | Problems: ${problems.length}\n`);
+
+        const header = ['examId', 'local', 'db', 'status', 'note'];
+        const widths = [40, 6, 6, 18, 60];
+        const fmt = (cols: string[]) =>
+            cols.map((c, i) => c.padEnd(widths[i]).slice(0, widths[i])).join(' | ');
+        console.log(fmt(header));
+        console.log(widths.map((w) => '-'.repeat(w)).join('-+-'));
+        for (const r of rows) {
+            console.log(
+                fmt([
+                    r.examId,
+                    String(r.localQuestionCount),
+                    String(r.dbQuestionCount),
+                    r.status,
+                    r.note ?? '',
+                ])
+            );
+        }
+
+        if (problems.length > 0) {
+            console.log(`\n[verify] FAIL: ${problems.length} examId(s) need attention. See rows above.`);
+        } else {
+            console.log(`\n[verify] OK: all examIds have non-zero questions in DB.`);
+        }
+    }
+
+    process.exit(problems.length > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+    console.error('[verify] Unexpected failure:', e);
+    process.exit(2);
+});


### PR DESCRIPTION
Closes #208

## 背景

Issue #208 で `SA-2024-Spring-PM1/PM1/1?mode=practice` が「問題が見つかりません」と表示される事象を分析した結果、以下が判明:

- ローカル `packages/data` には JSON が存在
- 本番では Cosmos の Questions コンテナに該当 examId のレコードが未投入の可能性が高い
- `next.config.js` が `output: 'standalone'` のため `packages/data` は本番バンドルに同梱されず、`getExamData()` のFSフォールバックは効かない
- Cosmos アクセス失敗時のログが握り潰されており、本番で原因特定不可能
- ユーザーには一律「問題が見つかりません」しか表示されず、データ未投入かバグか区別できない

## 変更内容

### 1. exam ページのエラーハンドリング改善 (`apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx`)
- データ取得状態を `ok` / `db_error` / `data_unavailable` で区別
- Cosmos エラー時の `console.error` / `console.warn` を復活 (本番ログから追跡可能に)
- FSフォールバックを `NODE_ENV !== 'production'` に限定 (standalone build で誤って本番に効くと思い込まないようガード)
- Not Found 画面を以下の3パターンで出し分け:
  - DB エラー: 「一時的なデータ取得エラー」
  - データ未準備: 「データがまだ準備されていません」
  - 番号不一致: 従来通り「問題番号が範囲外」

### 2. カバレッジ検証スクリプト新規追加 (`packages/data/src/scripts/verify-data-coverage.ts`)
- ローカル `questions/**` の examId/件数 と Cosmos `Questions` コンテナの実投入状況を照合
- ギャップを検出して終了コードで通知 (0=OK, 1=ギャップあり, 2=接続失敗)
- `--exam <ID>` で個別検証、`--json` で機械可読出力にも対応
- `npm run verify-coverage --workspace=packages/data` で実行可能

### 3. 手順書更新 (`.github/prompts/sync-cosmosdb.prompt.md`)
- ステップ4.5として `verify-data-coverage` を必須実行に追加 (IP 解放前にギャップ検出)

## 運用方針

CosmosDB は Selected Networks (Zero Trust) 構成で IP 制限されているため、
CI/CD による完全自動化は困難。本 PR は **手動 sync 後の検証ガードレール** を整備することで、
「ローカル JSON はあるが Cosmos に未投入」という Issue #208 と同種の不具合を
本番投入前に検出できるようにする。

## テスト

- ✅ `npm run test:unit`: 510/510 passed
- ✅ `tsc --noEmit` (apps/web): エラーなし
- ⏸️ `verify-data-coverage` の実機検証: IP 制限のため別途許可された環境で要実施

## 類似リスクと未対応項目

調査の過程で発見した低優先度の追加リスク (本 PR スコープ外):
- `sync-db.ts` の `isPMExam` 判定: SA/ST/AU は `type.startsWith('PM')` で救われているが明示的でない
- `QuestionClient.tsx` の `isPM` 判定が `subQuestions` 参照のみで、PM 単体型に限界
- `typeSuffix` 算出に `AM1→AM` の特例しかない

これらは別 Issue として切り出すか、本番調査結果を踏まえて優先度判断を推奨。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>