### PR TITLE
feat(plan): 学習計画エディタ（休/集中トグル + 再計画プレビュー） (#189)

### DIFF
--- a/apps/web/__tests__/lib/replan.test.ts
+++ b/apps/web/__tests__/lib/replan.test.ts
@@ -196,4 +196,22 @@ describe('replan', () => {
         expect(r.diff.totalDebtQuestions).toBe(0);
         expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(5);
     });
+
+    it('does not throw when a week has undefined dailyTasks (regression: defense-in-depth for #189)', () => {
+        const plan = buildPlan([
+            { date: '2026-04-21', questionCount: 5 },
+            { date: '2026-04-22', questionCount: 5 },
+        ]);
+        // 未生成週を末尾に追加（dailyTasks 欠落）
+        plan.weeklySchedule.push({
+            weekNumber: 2,
+            startDate: '2026-04-28',
+            endDate: '2026-05-04',
+            goal: 'transition week (not yet generated)',
+        } as unknown as (typeof plan.weeklySchedule)[number]);
+
+        expect(() => replan({ plan, dailyProgress: [], today: '2026-04-21', options: { now } })).not.toThrow();
+        const r = replan({ plan, dailyProgress: [], today: '2026-04-21', options: { now } });
+        expect(r.plan.weeklySchedule[1].dailyTasks).toEqual([]);
+    });
 });

--- a/apps/web/__tests__/lib/study-plan/planEditActions.test.ts
+++ b/apps/web/__tests__/lib/study-plan/planEditActions.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+    applyEditState,
+    cycleEditMode,
+    setEditMode,
+    listAllDates,
+    type EditState,
+} from '@/lib/study-plan/planEditActions';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+
+const basePlan: StudyPlan = {
+    id: 'plan-1',
+    title: 'AP 2025 Spring',
+    targetExam: 'AP',
+    examDate: '2025-04-20',
+    monthlyGoal: '基礎を固める',
+    generatedAt: '2025-01-01T00:00:00.000Z',
+    weeklySchedule: [
+        {
+            weekNumber: 1,
+            startDate: '2025-01-06',
+            endDate: '2025-01-12',
+            goal: 'week 1',
+            dailyTasks: [
+                { date: '2025-01-06', goal: 'mon', questionCount: 10 },
+                { date: '2025-01-07', goal: 'tue', questionCount: 10 },
+                { date: '2025-01-08', goal: 'wed', questionCount: 12 },
+            ],
+        },
+    ],
+};
+
+describe('applyEditState', () => {
+    it('returns a new plan instance (immutability)', () => {
+        const next = applyEditState(basePlan, {});
+        expect(next).not.toBe(basePlan);
+        expect(next.weeklySchedule).not.toBe(basePlan.weeklySchedule);
+        expect(next.weeklySchedule[0].dailyTasks).not.toBe(basePlan.weeklySchedule[0].dailyTasks);
+    });
+
+    it('keeps questionCount when no edits', () => {
+        const next = applyEditState(basePlan, {});
+        expect(next.weeklySchedule[0].dailyTasks.map((t) => t.questionCount)).toEqual([10, 10, 12]);
+    });
+
+    it('rest mode zeros questionCount', () => {
+        const edits: EditState = { '2025-01-07': 'rest' };
+        const next = applyEditState(basePlan, edits);
+        expect(next.weeklySchedule[0].dailyTasks[1].questionCount).toBe(0);
+    });
+
+    it('focus mode multiplies questionCount by 1.5 (rounded)', () => {
+        const edits: EditState = { '2025-01-08': 'focus' };
+        const next = applyEditState(basePlan, edits);
+        expect(next.weeklySchedule[0].dailyTasks[2].questionCount).toBe(18);
+    });
+
+    it('does not mutate the input plan', () => {
+        const snapshot = JSON.parse(JSON.stringify(basePlan));
+        applyEditState(basePlan, { '2025-01-06': 'rest', '2025-01-08': 'focus' });
+        expect(basePlan).toEqual(snapshot);
+    });
+});
+
+describe('cycleEditMode', () => {
+    it('rotates undefined -> rest -> focus -> normal -> rest', () => {
+        expect(cycleEditMode(undefined)).toBe('rest');
+        expect(cycleEditMode('rest')).toBe('focus');
+        expect(cycleEditMode('focus')).toBe('normal');
+        expect(cycleEditMode('normal')).toBe('rest');
+    });
+});
+
+describe('setEditMode', () => {
+    it('removes the entry when mode=normal', () => {
+        const state: EditState = { '2025-01-06': 'rest' };
+        const next = setEditMode(state, '2025-01-06', 'normal');
+        expect(next).toEqual({});
+    });
+
+    it('sets non-normal modes', () => {
+        expect(setEditMode({}, '2025-01-06', 'focus')).toEqual({ '2025-01-06': 'focus' });
+    });
+
+    it('returns a new object (immutability)', () => {
+        const state: EditState = {};
+        const next = setEditMode(state, '2025-01-06', 'rest');
+        expect(next).not.toBe(state);
+    });
+});
+
+describe('listAllDates', () => {
+    it('returns dates sorted', () => {
+        expect(listAllDates(basePlan)).toEqual(['2025-01-06', '2025-01-07', '2025-01-08']);
+    });
+});

--- a/apps/web/__tests__/lib/study-plan/planEditActions.test.ts
+++ b/apps/web/__tests__/lib/study-plan/planEditActions.test.ts
@@ -93,4 +93,42 @@ describe('listAllDates', () => {
     it('returns dates sorted', () => {
         expect(listAllDates(basePlan)).toEqual(['2025-01-06', '2025-01-07', '2025-01-08']);
     });
+
+    it('handles weeks where dailyTasks is undefined (regression: #189 staging crash)', () => {
+        const planWithEmptyWeek: StudyPlan = {
+            ...basePlan,
+            weeklySchedule: [
+                ...basePlan.weeklySchedule,
+                {
+                    weekNumber: 2,
+                    startDate: '2025-01-13',
+                    endDate: '2025-01-19',
+                    goal: 'transition week (not yet generated)',
+                    // dailyTasks is intentionally omitted
+                } as unknown as (typeof basePlan.weeklySchedule)[number],
+            ],
+        };
+        expect(() => listAllDates(planWithEmptyWeek)).not.toThrow();
+        expect(listAllDates(planWithEmptyWeek)).toEqual(['2025-01-06', '2025-01-07', '2025-01-08']);
+    });
+});
+
+describe('applyEditState (regression)', () => {
+    it('does not throw when a week has no dailyTasks', () => {
+        const planWithEmptyWeek: StudyPlan = {
+            ...basePlan,
+            weeklySchedule: [
+                ...basePlan.weeklySchedule,
+                {
+                    weekNumber: 2,
+                    startDate: '2025-01-13',
+                    endDate: '2025-01-19',
+                    goal: 'transition week',
+                } as unknown as (typeof basePlan.weeklySchedule)[number],
+            ],
+        };
+        expect(() => applyEditState(planWithEmptyWeek, {})).not.toThrow();
+        const next = applyEditState(planWithEmptyWeek, {});
+        expect(next.weeklySchedule[1].dailyTasks).toEqual([]);
+    });
 });

--- a/apps/web/__tests__/lib/study-plan/useUndoRedo.test.ts
+++ b/apps/web/__tests__/lib/study-plan/useUndoRedo.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUndoRedo, MAX_HISTORY } from '@/lib/study-plan/useUndoRedo';
+
+describe('useUndoRedo', () => {
+    it('starts with initial value, no undo/redo available', () => {
+        const { result } = renderHook(() => useUndoRedo({ a: 1 }));
+        expect(result.current.present).toEqual({ a: 1 });
+        expect(result.current.canUndo).toBe(false);
+        expect(result.current.canRedo).toBe(false);
+    });
+
+    it('set + undo restores previous', () => {
+        const { result } = renderHook(() => useUndoRedo(0));
+        act(() => result.current.set(1));
+        act(() => result.current.set(2));
+        expect(result.current.present).toBe(2);
+        act(() => result.current.undo());
+        expect(result.current.present).toBe(1);
+        act(() => result.current.undo());
+        expect(result.current.present).toBe(0);
+        expect(result.current.canUndo).toBe(false);
+    });
+
+    it('redo restores future after undo', () => {
+        const { result } = renderHook(() => useUndoRedo(0));
+        act(() => result.current.set(1));
+        act(() => result.current.undo());
+        expect(result.current.canRedo).toBe(true);
+        act(() => result.current.redo());
+        expect(result.current.present).toBe(1);
+        expect(result.current.canRedo).toBe(false);
+    });
+
+    it('caps history at MAX_HISTORY', () => {
+        const { result } = renderHook(() => useUndoRedo(0));
+        for (let i = 1; i <= MAX_HISTORY + 3; i++) {
+            act(() => result.current.set(i));
+        }
+        // Undo as much as possible -> should not return to 0 (it was overwritten)
+        let undoCount = 0;
+        while (result.current.canUndo) {
+            act(() => result.current.undo());
+            undoCount++;
+            if (undoCount > MAX_HISTORY + 5) break; // safety
+        }
+        expect(undoCount).toBeLessThanOrEqual(MAX_HISTORY);
+    });
+
+    it('set after undo clears future (redo unavailable)', () => {
+        const { result } = renderHook(() => useUndoRedo(0));
+        act(() => result.current.set(1));
+        act(() => result.current.set(2));
+        act(() => result.current.undo());
+        act(() => result.current.set(99));
+        expect(result.current.canRedo).toBe(false);
+        expect(result.current.present).toBe(99);
+    });
+
+    it('reset clears history', () => {
+        const { result } = renderHook(() => useUndoRedo(0));
+        act(() => result.current.set(1));
+        act(() => result.current.set(2));
+        act(() => result.current.reset(10));
+        expect(result.current.present).toBe(10);
+        expect(result.current.canUndo).toBe(false);
+        expect(result.current.canRedo).toBe(false);
+    });
+});

--- a/apps/web/components/features/dashboard/GoalSettingWizard.tsx
+++ b/apps/web/components/features/dashboard/GoalSettingWizard.tsx
@@ -3,46 +3,9 @@
 import { useState, useEffect } from 'react';
 import styles from './GoalSettingWizard.module.css';
 import { getExamTypeName } from '@/lib/exam-utils';
+import type { StudyPlan, MonthlyGoal } from '@/lib/types/studyPlan';
 
-export interface MonthlyGoal {
-    id: string;
-    label: string;
-    type: 'questionCount' | 'accuracy' | 'studyDays' | 'correctCount' | 'custom';
-    targetValue: number;
-    unit: string;
-    iconEmoji: string;
-}
-
-export interface StudyPlan {
-    id: string;
-    title: string;
-    targetExam: string;
-    examDate: string;
-    hoursWeekday?: number; // 平日の学習時間
-    hoursWeekend?: number; // 休日の学習時間
-    monthlyGoal: string;
-    monthlyGoals?: MonthlyGoal[];
-    weeklySchedule: {
-        weekNumber: number;
-        startDate: string;
-        endDate: string;
-        theme?: string; // 週のテーマ
-        goal: string;
-        dailyTasks: {
-            date: string;
-            missionTitle?: string; // ミッション名（ゲーム風）
-            goal: string;
-            questionCount: number;
-            targetCategory: string;
-            targetExamId?: string;
-            difficulty?: 'easy' | 'normal' | 'hard';
-            xpReward?: number;
-            isCompleted?: boolean;
-        }[];
-    }[];
-    generatedAt: string;
-    totalXpEarned?: number;
-}
+export type { StudyPlan, MonthlyGoal };
 
 interface GoalSettingWizardProps {
     onClose: () => void;

--- a/apps/web/components/features/plan/PlanViewer.tsx
+++ b/apps/web/components/features/plan/PlanViewer.tsx
@@ -2,16 +2,18 @@
 
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { StudyPlan } from '../dashboard/GoalSettingWizard';
+import type { StudyPlan } from '@/lib/types/studyPlan';
 import { LearningRecord, getLearningRecords } from '@/lib/api';
 import { guestManager } from '@/lib/guest-manager';
 import Link from 'next/link';
+import PlanEditor from '@/components/features/study-plan/PlanEditor';
 
 export default function PlanViewer() {
     const { data: session, status } = useSession();
     const [plans, setPlans] = useState<StudyPlan[]>([]);
     const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
     const [dailyCounts, setDailyCounts] = useState<Record<string, number>>({});
+    const [editing, setEditing] = useState(false);
 
     // 1. Load Plans
     useEffect(() => {
@@ -89,6 +91,14 @@ export default function PlanViewer() {
         const newPlans = plans.map(p => p.id === updatedPlan.id ? updatedPlan : p);
         setPlans(newPlans);
         localStorage.setItem('studyPlans', JSON.stringify(newPlans));
+    };
+
+    /** PlanEditor からの「適用」を受けて、現在選択中の plan を更新する */
+    const handleApplyEdit = (newPlan: StudyPlan) => {
+        if (!activePlan) return;
+        const merged: StudyPlan = { ...newPlan, id: activePlan.id };
+        handleUpdatePlan(merged);
+        setEditing(false);
     };
 
     if (plans.length === 0) {
@@ -181,22 +191,46 @@ export default function PlanViewer() {
                                     )}
                                 </div>
                             </div>
-                            <button
-                                onClick={() => handleDelete(activePlan.id)}
-                                style={{
-                                    padding: '0.5rem 1rem',
-                                    background: '#ef4444',
-                                    color: 'white',
-                                    border: 'none',
-                                    borderRadius: '6px',
-                                    cursor: 'pointer',
-                                    fontSize: '0.8rem'
-                                }}
-                            >
-                                削除
-                            </button>
+                            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                                <button
+                                    onClick={() => setEditing(e => !e)}
+                                    style={{
+                                        padding: '0.5rem 1rem',
+                                        background: editing ? 'var(--bg-secondary)' : 'var(--primary-color, #2563eb)',
+                                        color: editing ? 'var(--text-primary)' : 'white',
+                                        border: '1px solid var(--border-color, transparent)',
+                                        borderRadius: '6px',
+                                        cursor: 'pointer',
+                                        fontSize: '0.85rem'
+                                    }}
+                                >
+                                    {editing ? '編集モード解除' : '✏️ 計画を編集'}
+                                </button>
+                                <button
+                                    onClick={() => handleDelete(activePlan.id)}
+                                    style={{
+                                        padding: '0.5rem 1rem',
+                                        background: '#ef4444',
+                                        color: 'white',
+                                        border: 'none',
+                                        borderRadius: '6px',
+                                        cursor: 'pointer',
+                                        fontSize: '0.8rem'
+                                    }}
+                                >
+                                    削除
+                                </button>
+                            </div>
                         </div>
 
+                        {editing ? (
+                            <PlanEditor
+                                plan={activePlan}
+                                onApply={handleApplyEdit}
+                                onCancel={() => setEditing(false)}
+                            />
+                        ) : (
+                            <>
                         <h3 style={{ marginBottom: '1rem' }}>週間スケジュール</h3>
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
                             {activePlan.weeklySchedule.map((week, i) => {
@@ -284,6 +318,8 @@ export default function PlanViewer() {
                                 );
                             })}
                         </div>
+                            </>
+                        )}
                     </div>
                 ) : (
                     <div style={{ textAlign: 'center', padding: '3rem', color: 'var(--text-secondary)' }}>

--- a/apps/web/components/features/study-plan/PlanEditor.module.css
+++ b/apps/web/components/features/study-plan/PlanEditor.module.css
@@ -1,0 +1,258 @@
+/**
+ * StudyPlan 編集 UI のスタイル (#189 Phase 1)
+ */
+
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 12px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+}
+
+.toolbarLabel {
+    font-weight: 600;
+    color: #374151;
+    margin-right: 8px;
+}
+
+.button {
+    padding: 6px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #111827;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.button:hover:not(:disabled) {
+    background: #f3f4f6;
+}
+
+.button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.primary {
+    background: #2563eb;
+    color: #ffffff;
+    border-color: #2563eb;
+}
+
+.primary:hover:not(:disabled) {
+    background: #1d4ed8;
+}
+
+.danger {
+    background: #ffffff;
+    color: #b91c1c;
+    border-color: #fecaca;
+}
+
+.calendarGrid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 6px;
+}
+
+.weekdayHeader {
+    text-align: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: #6b7280;
+    padding: 4px 0;
+}
+
+.cell {
+    min-height: 76px;
+    padding: 6px;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    background: #ffffff;
+    cursor: pointer;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-family: inherit;
+}
+
+.cell:hover {
+    border-color: #93c5fd;
+    background: #eff6ff;
+}
+
+.cell:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 1px;
+}
+
+.cellEmpty {
+    background: transparent;
+    border-style: dashed;
+    cursor: default;
+}
+
+.cellRest {
+    background: #fef2f2;
+    border-color: #fca5a5;
+}
+
+.cellFocus {
+    background: #fef3c7;
+    border-color: #fbbf24;
+}
+
+.cellDate {
+    font-size: 11px;
+    font-weight: 600;
+    color: #6b7280;
+}
+
+.cellCount {
+    font-size: 13px;
+    color: #111827;
+}
+
+.cellMode {
+    font-size: 11px;
+    font-weight: 600;
+    margin-top: auto;
+}
+
+.cellModeRest {
+    color: #b91c1c;
+}
+
+.cellModeFocus {
+    color: #b45309;
+}
+
+.modalBackdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 16px;
+}
+
+.modal {
+    background: #ffffff;
+    border-radius: 12px;
+    max-width: 720px;
+    width: 100%;
+    max-height: 90vh;
+    overflow: auto;
+    padding: 24px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+}
+
+.modalHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.modalTitle {
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.modalActions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 16px;
+}
+
+.diffSection {
+    margin-bottom: 16px;
+}
+
+.diffSectionTitle {
+    font-size: 14px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 8px;
+}
+
+.diffList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 13px;
+}
+
+.diffList li {
+    padding: 4px 8px;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.warning {
+    background: #fef3c7;
+    border-left: 4px solid #fbbf24;
+    padding: 8px 12px;
+    border-radius: 4px;
+    color: #92400e;
+    font-size: 13px;
+    margin-bottom: 12px;
+}
+
+.error {
+    background: #fef2f2;
+    border-left: 4px solid #f87171;
+    padding: 8px 12px;
+    border-radius: 4px;
+    color: #991b1b;
+    font-size: 13px;
+}
+
+.legend {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.legendItem {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.legendSwatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    border: 1px solid #e5e7eb;
+}
+
+@media (max-width: 480px) {
+    .cell {
+        min-height: 60px;
+        padding: 4px;
+    }
+    .cellCount {
+        font-size: 11px;
+    }
+    .calendarGrid {
+        gap: 3px;
+    }
+}

--- a/apps/web/components/features/study-plan/PlanEditor.tsx
+++ b/apps/web/components/features/study-plan/PlanEditor.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+/**
+ * StudyPlan 編集UI Phase 1 (#189)
+ *
+ * - カレンダー上のセルをクリック → 通常 / 休 / 集 をローテーション切替
+ * - トグルが入るたびに `applyEditState` で plan を書き換え、
+ *   `POST /api/study-plan/replan` を呼んで diff プレビュー表示
+ * - 「適用」で localStorage('studyPlans') を更新（リロード後も維持）
+ * - Undo/Redo は最大 5 ステップ、Ctrl+Z / Ctrl+Shift+Z 対応
+ *
+ * 設計書: docs/02_design/21_StudyPlanEditUI.md
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import styles from './PlanEditor.module.css';
+import {
+    applyEditState,
+    cycleEditMode,
+    listAllDates,
+    type EditMode,
+    type EditState,
+} from '@/lib/study-plan/planEditActions';
+import { useUndoRedo } from '@/lib/study-plan/useUndoRedo';
+import type { StudyPlan, DailyTask } from '@/lib/types/studyPlan';
+
+interface ReplanResult {
+    plan: StudyPlan;
+    diff: {
+        moved: { fromDate: string; toDate: string; questionCount: number; reason: string }[];
+        overflowed: { fromDate: string; questionCount: number; reason: string }[];
+        totalDebtQuestions: number;
+        redistributedQuestions: number;
+    };
+    warnings?: string[];
+}
+
+interface Props {
+    plan: StudyPlan;
+    /** 「適用」が押されたとき呼ばれる。新しい plan を localStorage 等に保存する責務は呼び出し側 */
+    onApply?: (newPlan: StudyPlan) => void;
+    /** 「キャンセル」が押されたとき呼ばれる（編集モード解除など） */
+    onCancel?: () => void;
+}
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
+
+function weekdayIndex(date: string): number {
+    return new Date(`${date}T00:00:00Z`).getUTCDay();
+}
+
+function buildDateMap(plan: StudyPlan): Map<string, DailyTask> {
+    const map = new Map<string, DailyTask>();
+    for (const week of plan.weeklySchedule) {
+        for (const task of week.dailyTasks) {
+            map.set(task.date, task);
+        }
+    }
+    return map;
+}
+
+/** 連続するカレンダー grid（最初の週の日曜から、最後の週の土曜まで）を作る */
+function buildCalendarDates(allDates: string[]): string[] {
+    if (allDates.length === 0) return [];
+    const first = new Date(`${allDates[0]}T00:00:00Z`);
+    const last = new Date(`${allDates[allDates.length - 1]}T00:00:00Z`);
+
+    const start = new Date(first);
+    start.setUTCDate(start.getUTCDate() - start.getUTCDay()); // back to Sunday
+
+    const end = new Date(last);
+    end.setUTCDate(end.getUTCDate() + (6 - end.getUTCDay())); // forward to Saturday
+
+    const result: string[] = [];
+    const cur = new Date(start);
+    while (cur <= end) {
+        result.push(
+            `${cur.getUTCFullYear()}-${String(cur.getUTCMonth() + 1).padStart(2, '0')}-${String(
+                cur.getUTCDate(),
+            ).padStart(2, '0')}`,
+        );
+        cur.setUTCDate(cur.getUTCDate() + 1);
+    }
+    return result;
+}
+
+export default function PlanEditor({ plan, onApply, onCancel }: Props) {
+    const editHistory = useUndoRedo<EditState>({});
+    const edits = editHistory.present;
+
+    const [preview, setPreview] = useState<ReplanResult | null>(null);
+    const [previewing, setPreviewing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [showModal, setShowModal] = useState(false);
+
+    const dateMap = useMemo(() => buildDateMap(plan), [plan]);
+    const allDates = useMemo(() => listAllDates(plan), [plan]);
+    const calendarDates = useMemo(() => buildCalendarDates(allDates), [allDates]);
+
+    const editedPlan = useMemo(() => applyEditState(plan, edits), [plan, edits]);
+
+    const hasEdits = Object.keys(edits).length > 0;
+
+    /** トグル: normal -> rest -> focus -> normal */
+    const handleCellClick = useCallback(
+        (date: string) => {
+            if (!dateMap.has(date)) return;
+            const next: EditState = { ...edits };
+            const newMode = cycleEditMode(next[date]);
+            if (newMode === 'normal') delete next[date];
+            else next[date] = newMode;
+            editHistory.set(next);
+        },
+        [dateMap, edits, editHistory],
+    );
+
+    /** プレビュー: replan API 呼び出し */
+    const requestPreview = useCallback(async () => {
+        setPreviewing(true);
+        setError(null);
+        try {
+            const res = await fetch('/api/study-plan/replan', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ plan: editedPlan }),
+            });
+            if (res.status === 401) {
+                throw new Error('プレビューにはログインが必要です');
+            }
+            if (!res.ok) {
+                throw new Error(`プレビュー取得に失敗しました (HTTP ${res.status})`);
+            }
+            const data = (await res.json()) as ReplanResult;
+            setPreview(data);
+            setShowModal(true);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : '不明なエラー');
+            setPreview(null);
+        } finally {
+            setPreviewing(false);
+        }
+    }, [editedPlan]);
+
+    const handleApply = useCallback(() => {
+        if (!preview) return;
+        onApply?.(preview.plan);
+        editHistory.reset({});
+        setPreview(null);
+        setShowModal(false);
+    }, [preview, onApply, editHistory]);
+
+    const handleCancelPreview = useCallback(() => {
+        setShowModal(false);
+    }, []);
+
+    // モーダル: Esc で閉じる
+    useEffect(() => {
+        if (!showModal) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setShowModal(false);
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [showModal]);
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.toolbar}>
+                <span className={styles.toolbarLabel}>編集モード</span>
+                <button
+                    type="button"
+                    className={styles.button}
+                    onClick={editHistory.undo}
+                    disabled={!editHistory.canUndo}
+                    aria-label="元に戻す (Ctrl+Z)"
+                >
+                    ↶ 元に戻す
+                </button>
+                <button
+                    type="button"
+                    className={styles.button}
+                    onClick={editHistory.redo}
+                    disabled={!editHistory.canRedo}
+                    aria-label="やり直し (Ctrl+Shift+Z)"
+                >
+                    ↷ やり直し
+                </button>
+                <button
+                    type="button"
+                    className={styles.button}
+                    onClick={() => editHistory.reset({})}
+                    disabled={!hasEdits}
+                >
+                    リセット
+                </button>
+                <span style={{ flex: 1 }} />
+                <button
+                    type="button"
+                    className={`${styles.button} ${styles.primary}`}
+                    onClick={requestPreview}
+                    disabled={!hasEdits || previewing}
+                >
+                    {previewing ? 'プレビュー中…' : '変更をプレビュー'}
+                </button>
+                {onCancel && (
+                    <button
+                        type="button"
+                        className={`${styles.button} ${styles.danger}`}
+                        onClick={onCancel}
+                    >
+                        編集を終了
+                    </button>
+                )}
+            </div>
+
+            <div className={styles.legend} aria-hidden="true">
+                <span className={styles.legendItem}>
+                    <span className={styles.legendSwatch} style={{ background: '#ffffff' }} /> 通常
+                </span>
+                <span className={styles.legendItem}>
+                    <span className={styles.legendSwatch} style={{ background: '#fef2f2', borderColor: '#fca5a5' }} /> 休
+                </span>
+                <span className={styles.legendItem}>
+                    <span className={styles.legendSwatch} style={{ background: '#fef3c7', borderColor: '#fbbf24' }} /> 集中
+                </span>
+                <span style={{ marginLeft: 'auto', color: '#9ca3af' }}>
+                    クリックで切替（通常 → 休 → 集中 → 通常）
+                </span>
+            </div>
+
+            {error && <div className={styles.error} role="alert">{error}</div>}
+
+            <div className={styles.calendarGrid} role="grid" aria-label="学習計画カレンダー">
+                {WEEKDAYS.map((w) => (
+                    <div key={w} className={styles.weekdayHeader} role="columnheader">
+                        {w}
+                    </div>
+                ))}
+                {calendarDates.map((date) => {
+                    const task = dateMap.get(date);
+                    const mode: EditMode = edits[date] ?? 'normal';
+                    if (!task) {
+                        return <div key={date} className={`${styles.cell} ${styles.cellEmpty}`} aria-hidden="true" />;
+                    }
+                    const dayNum = Number(date.slice(-2));
+                    const baseline = task.questionCount;
+                    const adjusted =
+                        mode === 'rest' ? 0 : mode === 'focus' ? Math.round(baseline * 1.5) : baseline;
+                    const cellClass = [
+                        styles.cell,
+                        mode === 'rest' ? styles.cellRest : '',
+                        mode === 'focus' ? styles.cellFocus : '',
+                    ]
+                        .filter(Boolean)
+                        .join(' ');
+                    const wd = WEEKDAYS[weekdayIndex(date)];
+                    const ariaLabel = `${date} ${wd}曜日、現在 ${adjusted} 問${
+                        mode === 'rest' ? '（休日）' : mode === 'focus' ? '（集中日）' : ''
+                    }、クリックで切替`;
+                    return (
+                        <button
+                            key={date}
+                            type="button"
+                            className={cellClass}
+                            onClick={() => handleCellClick(date)}
+                            aria-label={ariaLabel}
+                            aria-pressed={mode !== 'normal'}
+                        >
+                            <span className={styles.cellDate}>{dayNum}日 ({wd})</span>
+                            <span className={styles.cellCount}>{adjusted} 問</span>
+                            {mode === 'rest' && (
+                                <span className={`${styles.cellMode} ${styles.cellModeRest}`}>休日</span>
+                            )}
+                            {mode === 'focus' && (
+                                <span className={`${styles.cellMode} ${styles.cellModeFocus}`}>集中</span>
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+
+            {showModal && preview && (
+                <div
+                    className={styles.modalBackdrop}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="replan-preview-title"
+                    onClick={handleCancelPreview}
+                >
+                    <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+                        <div className={styles.modalHeader}>
+                            <h3 id="replan-preview-title" className={styles.modalTitle}>
+                                再計画プレビュー
+                            </h3>
+                        </div>
+
+                        {preview.warnings && preview.warnings.length > 0 && (
+                            <div className={styles.warning}>
+                                <strong>注意:</strong>
+                                <ul style={{ margin: '4px 0 0 20px', padding: 0 }}>
+                                    {preview.warnings.map((w, i) => (
+                                        <li key={i}>{w}</li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        <div className={styles.diffSection}>
+                            <div className={styles.diffSectionTitle}>
+                                総再配分量: {preview.diff.redistributedQuestions} / {preview.diff.totalDebtQuestions} 問
+                            </div>
+                        </div>
+
+                        {preview.diff.moved.length > 0 && (
+                            <div className={styles.diffSection}>
+                                <div className={styles.diffSectionTitle}>移動 ({preview.diff.moved.length} 件)</div>
+                                <ul className={styles.diffList}>
+                                    {preview.diff.moved.slice(0, 30).map((m, i) => (
+                                        <li key={i}>
+                                            {m.fromDate} → {m.toDate}: {m.questionCount} 問
+                                        </li>
+                                    ))}
+                                    {preview.diff.moved.length > 30 && (
+                                        <li>...他 {preview.diff.moved.length - 30} 件</li>
+                                    )}
+                                </ul>
+                            </div>
+                        )}
+
+                        {preview.diff.overflowed.length > 0 && (
+                            <div className={styles.diffSection}>
+                                <div className={styles.diffSectionTitle}>
+                                    収まりきらない分 ({preview.diff.overflowed.length} 件)
+                                </div>
+                                <ul className={styles.diffList}>
+                                    {preview.diff.overflowed.map((o, i) => (
+                                        <li key={i}>
+                                            {o.fromDate}: {o.questionCount} 問 ({o.reason})
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        <div className={styles.modalActions}>
+                            <button
+                                type="button"
+                                className={styles.button}
+                                onClick={handleCancelPreview}
+                            >
+                                やめる
+                            </button>
+                            <button
+                                type="button"
+                                className={`${styles.button} ${styles.primary}`}
+                                onClick={handleApply}
+                            >
+                                適用
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/web/components/features/study-plan/PlanEditor.tsx
+++ b/apps/web/components/features/study-plan/PlanEditor.tsx
@@ -52,7 +52,7 @@ function weekdayIndex(date: string): number {
 function buildDateMap(plan: StudyPlan): Map<string, DailyTask> {
     const map = new Map<string, DailyTask>();
     for (const week of plan.weeklySchedule) {
-        for (const task of week.dailyTasks) {
+        for (const task of week.dailyTasks ?? []) {
             map.set(task.date, task);
         }
     }
@@ -162,6 +162,26 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
         window.addEventListener('keydown', handler);
         return () => window.removeEventListener('keydown', handler);
     }, [showModal]);
+
+    if (allDates.length === 0) {
+        return (
+            <div className={styles.container}>
+                <div className={styles.warning} role="status">
+                    この計画には編集可能な日次タスクがありません。詳細タスクが生成された計画を選択してください。
+                </div>
+                {onCancel && (
+                    <button
+                        type="button"
+                        className={`${styles.button} ${styles.danger}`}
+                        onClick={onCancel}
+                        style={{ alignSelf: 'flex-start' }}
+                    >
+                        編集を終了
+                    </button>
+                )}
+            </div>
+        );
+    }
 
     return (
         <div className={styles.container}>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,3 +1,6 @@
+import type { StudyPlan } from '@/lib/types/studyPlan';
+export type { StudyPlan, MonthlyGoal, DailyTask, WeeklyScheduleItem, Difficulty } from '@/lib/types/studyPlan';
+
 const isClient = typeof window !== 'undefined';
 
 export function normalizeApiBase(baseUrl: string): string {
@@ -106,46 +109,6 @@ export interface StudyPlanJob {
     completedAt?: string;
     notifiedAt?: string; // ユーザーに通知した時刻
     dismissed?: boolean; // ユーザーが通知を破棄した場合
-}
-
-export interface MonthlyGoal {
-    id: string;
-    label: string;
-    type: 'questionCount' | 'accuracy' | 'studyDays' | 'correctCount' | 'custom';
-    targetValue: number;
-    unit: string;
-    iconEmoji: string;
-}
-
-export interface StudyPlan {
-    title: string;
-    examDate: string;
-    hoursWeekday?: number; // 平日の学習時間
-    hoursWeekend?: number; // 休日の学習時間
-    monthlyGoal: string; // Current month's goal (summary text, backward compat)
-    monthlyGoals?: MonthlyGoal[]; // Quantitative mid-term targets
-    weeklySchedule: {
-        weekNumber: number;
-        startDate: string; // ISO Date
-        endDate: string; // ISO Date
-        theme?: string; // 週のテーマ（例: ネットワーク基礎）
-        goal: string;
-        dailyTasks: {
-            date: string; // ISO Date "YYYY-MM-DD"
-            missionTitle?: string; // ミッション名（ゲーム風）
-            goal: string;
-            questionCount: number;
-            targetCategory?: string; // e.g. "セキュリティ"
-            targetExamId?: string; // e.g. "AP-2023-Fall"
-            difficulty?: 'easy' | 'normal' | 'hard'; // 難易度
-            xpReward?: number; // 獲得XP
-            isCompleted?: boolean; // 完了フラグ（クライアント側で管理）
-        }[];
-        focus?: string; // "Weakness Reinforcement"
-    }[];
-    generatedAt: string;
-    // ゲーミフィケーション用累計（クライアント側で計算）
-    totalXpEarned?: number;
 }
 
 /**

--- a/apps/web/lib/plan/replan.ts
+++ b/apps/web/lib/plan/replan.ts
@@ -90,7 +90,7 @@ export function replan(input: ReplanInput): ReplanResult {
     const pastDebts: { date: string; debt: number }[] = [];
 
     plan.weeklySchedule.forEach((week, wi) => {
-        week.dailyTasks.forEach((task, ti) => {
+        (week.dailyTasks ?? []).forEach((task, ti) => {
             if (task.date < today) {
                 const actual = progressByDate.get(task.date)?.questionCount ?? 0;
                 const required = Math.ceil(task.questionCount * opts.completionThreshold);
@@ -147,7 +147,7 @@ export function replan(input: ReplanInput): ReplanResult {
         ...plan,
         weeklySchedule: plan.weeklySchedule.map((week) => ({
             ...week,
-            dailyTasks: week.dailyTasks.map((task) => {
+            dailyTasks: (week.dailyTasks ?? []).map((task) => {
                 if (task.date < today) return { ...task };
                 if (task.date > plan.examDate) return { ...task };
                 const newCount = assigned.get(task.date) ?? task.questionCount;

--- a/apps/web/lib/study-plan/planEditActions.ts
+++ b/apps/web/lib/study-plan/planEditActions.ts
@@ -1,0 +1,116 @@
+/**
+ * StudyPlan 編集の純粋関数 (#189 設計書 ｧ9.1)
+ *
+ * v1.0 の `replan(input)` は `pinnedRestDays` / `pinnedFocusDays` を直接扱えないため、
+ * Phase 1 では「plan を書き換えてから replan に渡す」方式を採用する:
+ *   - 休日 ON: 対象日の questionCount を 0 に → debt として未来日へ再配分
+ *   - 集中日 ON: 対象日の questionCount を round(base * 1.5) に → 吸収枠を拡張
+ *
+ * 元の questionCount は `restDayBaseline` で保持し、OFF 復帰時に元に戻せるようにする。
+ * 入力 plan は immutable に扱い、必ず新しいオブジェクトを返す。
+ */
+
+import type { StudyPlan, DailyTask, WeeklyScheduleItem } from '@/lib/types/studyPlan';
+
+export type EditMode = 'rest' | 'focus' | 'normal';
+
+/** 編集状態（カレンダー上のオーバーレイ）。日付 -> モード */
+export type EditState = Record<string, EditMode>;
+
+const FOCUS_MULTIPLIER = 1.5;
+
+interface AppliedTask extends DailyTask {
+    /** 編集前の元の問題数（roundtrip 用） */
+    _baseline?: number;
+}
+
+interface AppliedWeek extends WeeklyScheduleItem {
+    dailyTasks: AppliedTask[];
+}
+
+interface AppliedPlan extends StudyPlan {
+    weeklySchedule: AppliedWeek[];
+}
+
+/**
+ * 編集 state を plan に反映した新しい plan を返す。
+ *
+ * - mode='rest'   : questionCount = 0
+ * - mode='focus'  : questionCount = round(baseline * 1.5)
+ * - mode='normal' : 何もしない（baseline と同じ）
+ *
+ * baseline は「呼び出し時点の plan の questionCount」を採用する。
+ * したがって本関数は「常に元の plan + 完全な edit state」から呼ぶ前提。
+ */
+export function applyEditState(plan: StudyPlan, edits: EditState): StudyPlan {
+    const next: AppliedPlan = {
+        ...plan,
+        weeklySchedule: plan.weeklySchedule.map((week) => ({
+            ...week,
+            dailyTasks: week.dailyTasks.map((task) => {
+                const mode = edits[task.date] ?? 'normal';
+                const baseline = task.questionCount;
+                let questionCount = baseline;
+                if (mode === 'rest') {
+                    questionCount = 0;
+                } else if (mode === 'focus') {
+                    questionCount = Math.round(baseline * FOCUS_MULTIPLIER);
+                }
+                return {
+                    ...task,
+                    questionCount,
+                    _baseline: baseline,
+                };
+            }),
+        })),
+    };
+    return next;
+}
+
+/**
+ * 単一日のモードを切り替える。
+ *
+ * UI のクリック1回で normal -> rest -> focus -> normal とローテーション。
+ */
+export function cycleEditMode(current: EditMode | undefined): EditMode {
+    switch (current) {
+        case 'rest':
+            return 'focus';
+        case 'focus':
+            return 'normal';
+        case 'normal':
+        case undefined:
+        default:
+            return 'rest';
+    }
+}
+
+/** 単一日を直接指定モードに設定（明示ボタン用） */
+export function setEditMode(state: EditState, date: string, mode: EditMode): EditState {
+    if (mode === 'normal') {
+        // normal は省略表現
+        const next = { ...state };
+        delete next[date];
+        return next;
+    }
+    return { ...state, [date]: mode };
+}
+
+/** 編集 state を空に戻す */
+export function clearEditState(): EditState {
+    return {};
+}
+
+/**
+ * plan 内の全日付（YYYY-MM-DD）を昇順で返す。
+ * カレンダー描画・diff 表示で使う。
+ */
+export function listAllDates(plan: StudyPlan): string[] {
+    const dates: string[] = [];
+    for (const week of plan.weeklySchedule) {
+        for (const task of week.dailyTasks) {
+            dates.push(task.date);
+        }
+    }
+    return dates.sort();
+}

--- a/apps/web/lib/study-plan/planEditActions.ts
+++ b/apps/web/lib/study-plan/planEditActions.ts
@@ -47,7 +47,7 @@ export function applyEditState(plan: StudyPlan, edits: EditState): StudyPlan {
         ...plan,
         weeklySchedule: plan.weeklySchedule.map((week) => ({
             ...week,
-            dailyTasks: week.dailyTasks.map((task) => {
+            dailyTasks: (week.dailyTasks ?? []).map((task) => {
                 const mode = edits[task.date] ?? 'normal';
                 const baseline = task.questionCount;
                 let questionCount = baseline;
@@ -108,7 +108,7 @@ export function clearEditState(): EditState {
 export function listAllDates(plan: StudyPlan): string[] {
     const dates: string[] = [];
     for (const week of plan.weeklySchedule) {
-        for (const task of week.dailyTasks) {
+        for (const task of week.dailyTasks ?? []) {
             dates.push(task.date);
         }
     }

--- a/apps/web/lib/study-plan/useUndoRedo.ts
+++ b/apps/web/lib/study-plan/useUndoRedo.ts
@@ -1,0 +1,89 @@
+'use client';
+
+/**
+ * Undo/Redo 履歴スタック (#189 DoD: 最大 5 ステップ、Ctrl+Z / Ctrl+Shift+Z)
+ *
+ * - past:    過去の state（古い順）
+ * - present: 現在の state
+ * - future:  redo 用の state（新しい順）
+ *
+ * past は MAX_HISTORY を超えたら先頭から捨てる。
+ */
+
+import { useCallback, useEffect, useReducer } from 'react';
+
+export const MAX_HISTORY = 5;
+
+interface State<T> {
+    past: T[];
+    present: T;
+    future: T[];
+}
+
+type Action<T> = { type: 'set'; value: T } | { type: 'undo' } | { type: 'redo' } | { type: 'reset'; value: T };
+
+function reducer<T>(state: State<T>, action: Action<T>): State<T> {
+    switch (action.type) {
+        case 'set': {
+            const past = [...state.past, state.present].slice(-MAX_HISTORY);
+            return { past, present: action.value, future: [] };
+        }
+        case 'undo': {
+            if (state.past.length === 0) return state;
+            const previous = state.past[state.past.length - 1];
+            return {
+                past: state.past.slice(0, -1),
+                present: previous,
+                future: [state.present, ...state.future].slice(0, MAX_HISTORY),
+            };
+        }
+        case 'redo': {
+            if (state.future.length === 0) return state;
+            const next = state.future[0];
+            return {
+                past: [...state.past, state.present].slice(-MAX_HISTORY),
+                present: next,
+                future: state.future.slice(1),
+            };
+        }
+        case 'reset':
+            return { past: [], present: action.value, future: [] };
+    }
+}
+
+export function useUndoRedo<T>(initial: T) {
+    const [state, dispatch] = useReducer(reducer<T>, { past: [], present: initial, future: [] });
+
+    const set = useCallback((value: T) => dispatch({ type: 'set', value }), []);
+    const undo = useCallback(() => dispatch({ type: 'undo' }), []);
+    const redo = useCallback(() => dispatch({ type: 'redo' }), []);
+    const reset = useCallback((value: T) => dispatch({ type: 'reset', value }), []);
+
+    // Ctrl+Z / Ctrl+Shift+Z (Mac は Cmd でも動かす)
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            const mod = e.ctrlKey || e.metaKey;
+            if (!mod) return;
+            const key = e.key.toLowerCase();
+            if (key === 'z' && !e.shiftKey) {
+                e.preventDefault();
+                undo();
+            } else if ((key === 'z' && e.shiftKey) || key === 'y') {
+                e.preventDefault();
+                redo();
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [undo, redo]);
+
+    return {
+        present: state.present,
+        canUndo: state.past.length > 0,
+        canRedo: state.future.length > 0,
+        set,
+        undo,
+        redo,
+        reset,
+    };
+}

--- a/apps/web/lib/types/studyPlan.ts
+++ b/apps/web/lib/types/studyPlan.ts
@@ -1,0 +1,65 @@
+/**
+ * StudyPlan 共通型 (#189 設計書 §4 / 1本化)
+ *
+ * 以前は `apps/web/lib/api.ts` (id 無し) と
+ * `apps/web/components/features/dashboard/GoalSettingWizard.tsx` (id あり)
+ * の 2 か所で StudyPlan が重複定義されていた。
+ * 編集UI (#189) の前提として本ファイルに集約し、両者は re-export に切り替える。
+ */
+
+export type Difficulty = 'easy' | 'normal' | 'hard';
+
+export interface MonthlyGoal {
+    id: string;
+    label: string;
+    type: 'questionCount' | 'accuracy' | 'studyDays' | 'correctCount' | 'custom';
+    targetValue: number;
+    unit: string;
+    iconEmoji: string;
+}
+
+export interface DailyTask {
+    /** YYYY-MM-DD */
+    date: string;
+    missionTitle?: string;
+    goal: string;
+    questionCount: number;
+    targetCategory?: string;
+    targetExamId?: string;
+    difficulty?: Difficulty;
+    xpReward?: number;
+    isCompleted?: boolean;
+}
+
+export interface WeeklyScheduleItem {
+    weekNumber: number;
+    /** YYYY-MM-DD */
+    startDate: string;
+    /** YYYY-MM-DD */
+    endDate: string;
+    theme?: string;
+    goal: string;
+    focus?: string;
+    dailyTasks: DailyTask[];
+}
+
+export interface StudyPlan {
+    /**
+     * 計画 ID。
+     * 新規生成時は `crypto.randomUUID()` で必ず付与する。
+     * legacy localStorage データは DashboardClient のマイグレーションで補完される。
+     */
+    id: string;
+    title: string;
+    /** 'AP' | 'FE' | 'SC' | ... 暫定で string 受け */
+    targetExam?: string;
+    /** YYYY-MM-DD */
+    examDate: string;
+    hoursWeekday?: number;
+    hoursWeekend?: number;
+    monthlyGoal: string;
+    monthlyGoals?: MonthlyGoal[];
+    weeklySchedule: WeeklyScheduleItem[];
+    generatedAt: string;
+    totalXpEarned?: number;
+}


### PR DESCRIPTION
Closes #189 (Phase 1)

## 概要

`docs/02_design/21_StudyPlanEditUI.md` (PR #213) に基づく学習計画エディタ Phase 1 MVP です。
カレンダー上で **休日 / 集中日** をトグルし、動的再計画エンジン v1.0 (#188) で diff をプレビューしてから `localStorage('studyPlans')` に適用できます。

## 変更内容

### 1. StudyPlan 型の1本化（1コミット目）
- `apps/web/lib/types/studyPlan.ts` を新設し、`StudyPlan`（id 必須）/ `MonthlyGoal` / `WeeklyScheduleItem` / `DailyTask` / `Difficulty` を集約。
- `lib/api.ts` と `components/features/dashboard/GoalSettingWizard.tsx` は re-export に変更（既存の挙動は維持）。

### 2. エディタ本体（2コミット目）
- **`PlanEditor.tsx`** — カレンダーグリッド（日〜土）。セルクリックで `通常 → 休 → 集中 → 通常` を循環。ツールバー: Undo / Redo / リセット / プレビュー / 編集を終了。
- **`planEditActions.ts`** — 純粋関数:
  - `applyEditState(plan, edits)` — 休 → `questionCount=0`、集中 → `round(baseline × 1.5)`。
  - `cycleEditMode`, `setEditMode`, `listAllDates`。
  - 入力 plan は immutable。
- **`useUndoRedo.ts`** — 汎用履歴フック (`MAX_HISTORY=5`)。`Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y` を window レベルで束ねる。
- **`PlanEditor`** が `POST /api/study-plan/replan`（#188 で実装済）に編集後 plan を渡し、`moved` / `overflowed` / `warnings` をモーダル表示。
- 「適用」で `PlanViewer.handleApplyEdit` が `localStorage('studyPlans')` を更新（`plan.id` は維持）。

## DoD

- [x] StudyPlan 型を1本化
- [x] 休/集中トグル
- [x] replan API 呼び出し + diff プレビュー
- [x] 適用 → localStorage 永続化
- [x] Undo/Redo (5 ステップ, Ctrl+Z / Ctrl+Shift+Z)
- [x] a11y: `role=grid`, `aria-label`, `aria-pressed`, `role=dialog` + `aria-modal`, Esc で閉じる, focus-visible
- [x] レスポンシブ: 480px ブレークポイントでセル縮小

## テスト / ビルド

- `npx tsc --noEmit` ✅
- `npx vitest run` ✅ **535 / 535 pass**（既存 519 + 新規 16: planEditActions ×10, useUndoRedo ×6）
- `npm run build` ✅
- HTTP smoke: `GET /plan` → 200, ページ描画 OK

## レビュアーへの確認依頼

### 1. CI / ビルド（自動）
- GitHub Actions が全 green か（本 PR 画面下部のチェック）
- 落ちていたらログを共有してください

### 2. ステージングでの目視動作確認
`/plan` ページを開いて、以下のシナリオを試してください。

**前提**: `studyPlans` が localStorage に 1 件以上ある状態（無ければ Dashboard で計画作成）

| # | 操作 | 期待 |
|---|---|---|
| 1 | `✏️ 計画を編集` クリック | カレンダー（日〜土）に切替 |
| 2 | 任意セルをクリック | 赤（休）→ 黄（集中）→ 通常 と循環、問題数が `0` / `×1.5` / 元 に変化 |
| 3 | `↶ 元に戻す` | 直前の操作が取り消される |
| 4 | `Ctrl+Z` / `Ctrl+Shift+Z` | Undo/Redo がキーボードで動く（最大 5 段） |
| 5 | `変更をプレビュー` | モーダルに「移動 N 件」「収まりきらない分」「総再配分量」が表示 |
| 6 | モーダルで `適用` | モーダル閉じ、ビューに反映、**リロード後も維持**されること |
| 7 | モーダルで `やめる` / Esc / 背景クリック | モーダル閉じるが編集状態は保持 |
| 8 | モバイル幅（375px） | カレンダーが崩れない |

### 3. 仕様面で確認したいポイント
- **トグルの UX**: 1 クリックで「通常 → 休 → 集中」循環という仕様で問題ないか？（明示的な休/集ボタン 2 つに分けるパターンも可）
- **集中日 ×1.5 の倍率**: 妥当か？（設計書には根拠なし、暫定値）
- **未認証時**: プレビュー API が 401 を返しエラーバナーが出ます。ゲストでも編集できるようにすべきか？（現状は #212 でサーバ永続化と一緒に対応予定）

## スコープ外（Phase 2 派生 Issue）

- #211 タスク単位 D&D 移動
- #212 サーバ永続化 (Cosmos) + ゲストマージ

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;