### PR TITLE
feat(#212): 学習計画をサーバ永続化 (Cosmos StudyPlan)

### DIFF
--- a/apps/web/__tests__/api/study-plan.test.ts
+++ b/apps/web/__tests__/api/study-plan.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn(),
+}));
+
+vi.mock('@/auth', () => ({
+    authOptions: {},
+}));
+
+vi.mock('@/lib/repositories/studyPlanRepository', () => ({
+    studyPlanRepository: {
+        listByUser: vi.fn(),
+        findById: vi.fn(),
+        upsert: vi.fn(),
+        upsertMany: vi.fn(),
+        remove: vi.fn(),
+    },
+}));
+
+import { getServerSession } from 'next-auth';
+import { studyPlanRepository } from '@/lib/repositories/studyPlanRepository';
+import { GET as listGET, POST as listPOST } from '@/app/api/study-plan/route';
+import { GET as itemGET, PUT as itemPUT, DELETE as itemDELETE } from '@/app/api/study-plan/[id]/route';
+
+const mockGetServerSession = vi.mocked(getServerSession);
+const mockRepo = vi.mocked(studyPlanRepository);
+
+const validPlan = {
+    id: 'plan-1',
+    title: 't',
+    examDate: '2026-04-21',
+    monthlyGoal: 'g',
+    weeklySchedule: [
+        {
+            weekNumber: 1,
+            startDate: '2026-04-15',
+            endDate: '2026-04-21',
+            goal: 'w',
+            dailyTasks: [{ date: '2026-04-15', goal: 'g', questionCount: 10 }],
+        },
+    ],
+    generatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const makeReq = (body?: unknown, url = 'http://localhost/api/study-plan') =>
+    ({ json: async () => body, url } as any);
+
+describe('study-plan API routes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('GET /api/study-plan', () => {
+        it('未認証は 401', async () => {
+            mockGetServerSession.mockResolvedValue(null as any);
+            const res = await listGET();
+            expect(res.status).toBe(401);
+        });
+
+        it('認証済みは listByUser の結果を返す', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.listByUser.mockResolvedValue([validPlan as any]);
+            const res = await listGET();
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toHaveLength(1);
+            expect(mockRepo.listByUser).toHaveBeenCalledWith('u1');
+        });
+    });
+
+    describe('POST /api/study-plan', () => {
+        it('未認証は 401', async () => {
+            mockGetServerSession.mockResolvedValue(null as any);
+            const res = await listPOST(makeReq(validPlan));
+            expect(res.status).toBe(401);
+        });
+
+        it('単一 plan を upsert', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.upsert.mockResolvedValue(validPlan as any);
+            const res = await listPOST(makeReq(validPlan));
+            expect(res.status).toBe(200);
+            expect(mockRepo.upsert).toHaveBeenCalledWith('u1', expect.objectContaining({ id: 'plan-1' }));
+        });
+
+        it('配列は upsertMany にルーティング', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.upsertMany.mockResolvedValue(2);
+            const res = await listPOST(makeReq([validPlan, { ...validPlan, id: 'plan-2' }]));
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toEqual({ count: 2 });
+        });
+
+        it('不正データは 400', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            const res = await listPOST(makeReq({ id: 'x' }));
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('PUT /api/study-plan/[id]', () => {
+        it('id 不一致は 400', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            const res = await itemPUT(makeReq(validPlan), { params: Promise.resolve({ id: 'different' }) });
+            expect(res.status).toBe(400);
+        });
+
+        it('id 一致なら upsert', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.upsert.mockResolvedValue(validPlan as any);
+            const res = await itemPUT(makeReq(validPlan), { params: Promise.resolve({ id: 'plan-1' }) });
+            expect(res.status).toBe(200);
+        });
+    });
+
+    describe('GET /api/study-plan/[id]', () => {
+        it('未存在は 404', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.findById.mockResolvedValue(null);
+            const res = await itemGET(makeReq(), { params: Promise.resolve({ id: 'missing' }) });
+            expect(res.status).toBe(404);
+        });
+
+        it('存在すれば 200 で返す', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.findById.mockResolvedValue(validPlan as any);
+            const res = await itemGET(makeReq(), { params: Promise.resolve({ id: 'plan-1' }) });
+            expect(res.status).toBe(200);
+        });
+    });
+
+    describe('DELETE /api/study-plan/[id]', () => {
+        it('未認証は 401', async () => {
+            mockGetServerSession.mockResolvedValue(null as any);
+            const res = await itemDELETE(makeReq(), { params: Promise.resolve({ id: 'plan-1' }) });
+            expect(res.status).toBe(401);
+        });
+        it('成功時は { ok: true }', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.remove.mockResolvedValue(true);
+            const res = await itemDELETE(makeReq(), { params: Promise.resolve({ id: 'plan-1' }) });
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body).toEqual({ ok: true });
+        });
+        it('未存在は 404', async () => {
+            mockGetServerSession.mockResolvedValue({ user: { id: 'u1' } } as any);
+            mockRepo.remove.mockResolvedValue(false);
+            const res = await itemDELETE(makeReq(), { params: Promise.resolve({ id: 'missing' }) });
+            expect(res.status).toBe(404);
+        });
+    });
+});

--- a/apps/web/__tests__/lib/repositories/studyPlanRepository.test.ts
+++ b/apps/web/__tests__/lib/repositories/studyPlanRepository.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/cosmos', () => ({
+    getContainer: vi.fn(),
+}));
+
+import { getContainer } from '@/lib/cosmos';
+import { studyPlanRepository } from '@/lib/repositories/studyPlanRepository';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+
+const mockGetContainer = vi.mocked(getContainer);
+
+const samplePlan: StudyPlan = {
+    id: 'plan-1',
+    title: 'AP 春',
+    examDate: '2026-04-21',
+    monthlyGoal: '基礎理論を固める',
+    weeklySchedule: [
+        {
+            weekNumber: 1,
+            startDate: '2026-04-15',
+            endDate: '2026-04-21',
+            goal: 'w1',
+            dailyTasks: [
+                { date: '2026-04-15', goal: 'task', questionCount: 10 },
+            ],
+        },
+    ],
+    generatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('studyPlanRepository', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('listByUser: userId で絞った計画一覧を返し、userId を剥がす', async () => {
+        const fetchAllMock = vi.fn().mockResolvedValue({
+            resources: [{ ...samplePlan, userId: 'u1' }],
+        });
+        const queryMock = vi.fn(() => ({ fetchAll: fetchAllMock }));
+        mockGetContainer.mockResolvedValue({ items: { query: queryMock } } as any);
+
+        const result = await studyPlanRepository.listByUser('u1');
+
+        expect(queryMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                parameters: [{ name: '@userId', value: 'u1' }],
+            }),
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0]).not.toHaveProperty('userId');
+        expect(result[0].id).toBe('plan-1');
+    });
+
+    it('upsert: zod 検証を通り、保存後の resource から userId を剥がして返す', async () => {
+        const upsertMock = vi.fn().mockResolvedValue({
+            resource: { ...samplePlan, userId: 'u1' },
+        });
+        mockGetContainer.mockResolvedValue({ items: { upsert: upsertMock } } as any);
+
+        const saved = await studyPlanRepository.upsert('u1', samplePlan);
+
+        expect(upsertMock).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u1', id: 'plan-1' }));
+        expect(saved).not.toHaveProperty('userId');
+        expect(saved.id).toBe('plan-1');
+    });
+
+    it('upsertMany: 複数件を順次 upsert し件数を返す', async () => {
+        const upsertMock = vi.fn().mockResolvedValue({ resource: { ...samplePlan, userId: 'u1' } });
+        mockGetContainer.mockResolvedValue({ items: { upsert: upsertMock } } as any);
+
+        const n = await studyPlanRepository.upsertMany('u1', [samplePlan, { ...samplePlan, id: 'plan-2' }]);
+
+        expect(n).toBe(2);
+        expect(upsertMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('findById: 404 時は null を返す', async () => {
+        const readMock = vi.fn().mockRejectedValue({ code: 404 });
+        const itemMock = vi.fn(() => ({ read: readMock }));
+        mockGetContainer.mockResolvedValue({ item: itemMock } as any);
+
+        const result = await studyPlanRepository.findById('u1', 'missing');
+
+        expect(result).toBeNull();
+        expect(itemMock).toHaveBeenCalledWith('missing', 'u1');
+    });
+
+    it('remove: 404 時は false、成功時は true', async () => {
+        const deleteOk = vi.fn().mockResolvedValue({});
+        mockGetContainer.mockResolvedValue({ item: () => ({ delete: deleteOk }) } as any);
+        await expect(studyPlanRepository.remove('u1', 'plan-1')).resolves.toBe(true);
+
+        const deleteNotFound = vi.fn().mockRejectedValue({ statusCode: 404 });
+        mockGetContainer.mockResolvedValue({ item: () => ({ delete: deleteNotFound }) } as any);
+        await expect(studyPlanRepository.remove('u1', 'missing')).resolves.toBe(false);
+    });
+
+    it('upsert: 不正な plan は zod でエラー', async () => {
+        const badPlan = { id: 'p', title: 't' } as unknown as StudyPlan;
+        await expect(studyPlanRepository.upsert('u1', badPlan)).rejects.toThrow();
+    });
+});

--- a/apps/web/app/api/study-plan/[id]/route.ts
+++ b/apps/web/app/api/study-plan/[id]/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { studyPlanRepository } from '@/lib/repositories/studyPlanRepository';
+import { StudyPlanSchema } from '@/lib/types/studyPlanSchema';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/study-plan/[id]
+ */
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const { id } = await params;
+        const plan = await studyPlanRepository.findById(session.user.id, id);
+        if (!plan) {
+            return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+        }
+        return NextResponse.json(plan);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return NextResponse.json(
+            { error: 'Internal Server Error', details: message },
+            { status: 500 },
+        );
+    }
+}
+
+/**
+ * PUT /api/study-plan/[id]
+ * 既存計画を全置換 (upsert)。body の id は path id と一致必須。
+ */
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const { id } = await params;
+        const body = await request.json();
+        const parsed = StudyPlanSchema.safeParse(body);
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: 'Invalid data', details: parsed.error.format() },
+                { status: 400 },
+            );
+        }
+        if (parsed.data.id !== id) {
+            return NextResponse.json(
+                { error: 'id mismatch between body and path' },
+                { status: 400 },
+            );
+        }
+        const saved = await studyPlanRepository.upsert(session.user.id, parsed.data);
+        return NextResponse.json(saved);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return NextResponse.json(
+            { error: 'Internal Server Error', details: message },
+            { status: 500 },
+        );
+    }
+}
+
+/**
+ * DELETE /api/study-plan/[id]
+ */
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const { id } = await params;
+        const removed = await studyPlanRepository.remove(session.user.id, id);
+        if (!removed) {
+            return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+        }
+        return NextResponse.json({ ok: true });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return NextResponse.json(
+            { error: 'Internal Server Error', details: message },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web/app/api/study-plan/route.ts
+++ b/apps/web/app/api/study-plan/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { studyPlanRepository } from '@/lib/repositories/studyPlanRepository';
+import { StudyPlanSchema } from '@/lib/types/studyPlanSchema';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/study-plan
+ * 認証ユーザーの全学習計画を返す
+ */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const plans = await studyPlanRepository.listByUser(session.user.id);
+        return NextResponse.json(plans);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return NextResponse.json(
+            { error: 'Internal Server Error', details: message },
+            { status: 500 },
+        );
+    }
+}
+
+/**
+ * POST /api/study-plan
+ * - body: StudyPlan 1件 → 単発 upsert
+ * - body: StudyPlan[] → 一括 upsert（localStorage → サーバ移行用）
+ *
+ * 既存 id があれば上書き、無い場合はクライアント側で必ず id を採番済み。
+ */
+export async function POST(request: NextRequest) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const body = await request.json();
+
+        if (Array.isArray(body)) {
+            const parsed = z.array(StudyPlanSchema).safeParse(body);
+            if (!parsed.success) {
+                return NextResponse.json(
+                    { error: 'Invalid data', details: parsed.error.format() },
+                    { status: 400 },
+                );
+            }
+            const count = await studyPlanRepository.upsertMany(session.user.id, parsed.data);
+            return NextResponse.json({ count }, { status: 200 });
+        }
+
+        const parsed = StudyPlanSchema.safeParse(body);
+        if (!parsed.success) {
+            return NextResponse.json(
+                { error: 'Invalid data', details: parsed.error.format() },
+                { status: 400 },
+            );
+        }
+        const saved = await studyPlanRepository.upsert(session.user.id, parsed.data);
+        return NextResponse.json(saved, { status: 200 });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return NextResponse.json(
+            { error: 'Internal Server Error', details: message },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web/components/features/dashboard/DashboardClient.tsx
+++ b/apps/web/components/features/dashboard/DashboardClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
-import { LearningRecord, getLearningRecords, getQuestions, getExams, StudyPlanJob, Question } from '@/lib/api';
+import { LearningRecord, getLearningRecords, getQuestions, getExams, StudyPlanJob, Question, listStudyPlans, upsertStudyPlan, migrateLocalStudyPlansToServer } from '@/lib/api';
 import { guestManager } from '@/lib/guest-manager';
 import { getExamLabel } from '@/lib/exam-utils';
 import ThemeToggle from '@/components/common/ThemeToggle';
@@ -129,60 +129,75 @@ export default function DashboardClient() {
 
     // 2. Load Plan & Check URL Action
     useEffect(() => {
-        // Migration & Load Logic
-        const savedPlansStr = localStorage.getItem('studyPlans');
-        let allPlans: StudyPlan[] = [];
+        let cancelled = false;
 
-        if (savedPlansStr) {
-            try {
-                const parsed = JSON.parse(savedPlansStr);
-                setAllPlans(parsed);
-                allPlans = parsed;
-            } catch (e) {
-                console.error("Failed to parse studyPlans", e);
+        const hydrateFromPlans = (allPlans: StudyPlan[]) => {
+            if (cancelled) return;
+            setAllPlans(allPlans);
+            if (allPlans.length === 0) return;
+            const sorted = [...allPlans].sort((a, b) => new Date(a.examDate).getTime() - new Date(b.examDate).getTime());
+            const future = sorted.filter(p => new Date(p.examDate) >= new Date(new Date().setHours(0, 0, 0, 0)));
+            let active = future.length > 0 ? future[0] : sorted[sorted.length - 1];
+            if (active && !active.monthlyGoals) {
+                const defaults = createDefaultMonthlyGoals(active.weeklySchedule || []);
+                active = { ...active, monthlyGoals: defaults };
+                const updatedPlans = allPlans.map(p => p.id === active.id ? active : p);
+                localStorage.setItem('studyPlans', JSON.stringify(updatedPlans));
+                setAllPlans(updatedPlans);
+                // 認証ユーザーは server にも反映（best-effort, 非同期）
+                if (status === 'authenticated') {
+                    upsertStudyPlan(active).catch(() => {});
+                }
             }
-        } else {
-            // Check legacy single plan
+            setStudyPlan(active);
+        };
+
+        const loadFromLocalStorage = (): StudyPlan[] => {
+            const savedPlansStr = localStorage.getItem('studyPlans');
+            if (savedPlansStr) {
+                try {
+                    return JSON.parse(savedPlansStr);
+                } catch (e) {
+                    console.error("Failed to parse studyPlans", e);
+                    return [];
+                }
+            }
+            // legacy single plan migration
             const legacyPlanStr = localStorage.getItem('studyPlan');
             if (legacyPlanStr) {
                 try {
                     const legacyPlan = JSON.parse(legacyPlanStr);
-                    // Add ID if missing (legacy)
                     if (!legacyPlan.id) legacyPlan.id = crypto.randomUUID();
-                    allPlans = [legacyPlan];
-                    setAllPlans(allPlans);
-                    localStorage.setItem('studyPlans', JSON.stringify(allPlans));
+                    const arr = [legacyPlan];
+                    localStorage.setItem('studyPlans', JSON.stringify(arr));
+                    return arr;
                 } catch (e) {
                     console.error("Failed to migrate legacy plan", e);
                 }
             }
-        }
+            return [];
+        };
 
-        // Determine Active Plan
-        // Strategy: 1. If URL has ?planId=... use that. 
-        // 2. Else find nearest future exam.
-        // 3. Else fallback to first.
-
-        if (allPlans.length > 0) {
-            // Pick the one with closest future date.
-            const sorted = [...allPlans].sort((a, b) => new Date(a.examDate).getTime() - new Date(b.examDate).getTime());
-            // Filter future or today
-            const future = sorted.filter(p => new Date(p.examDate) >= new Date(new Date().setHours(0, 0, 0, 0)));
-
-            let active = future.length > 0 ? future[0] : sorted[sorted.length - 1]; // Nearest future or latest past
-
-            // monthlyGoals が未設定のプランにデフォルト値を自動付与
-            if (active && !active.monthlyGoals) {
-                const defaults = createDefaultMonthlyGoals(active.weeklySchedule || []);
-                active = { ...active, monthlyGoals: defaults };
-                // localStorageも更新
-                const updatedPlans = allPlans.map(p => p.id === active.id ? active : p);
-                localStorage.setItem('studyPlans', JSON.stringify(updatedPlans));
-                setAllPlans(updatedPlans);
+        const run = async () => {
+            // 1) 認証済み: localStorage → server へ一括移行（初回のみ）
+            //    その後 server → state、エラー時は localStorage へフォールバック
+            if (status === 'authenticated' && session?.user?.id) {
+                await migrateLocalStudyPlansToServer(session.user.id);
+                const fromServer = await listStudyPlans();
+                if (cancelled) return;
+                if (fromServer) {
+                    // server が正本。localStorage はオフラインフォールバック用に同期更新
+                    localStorage.setItem('studyPlans', JSON.stringify(fromServer));
+                    hydrateFromPlans(fromServer);
+                    return;
+                }
+                // server エラー → localStorage フォールバック
             }
+            // 2) 未認証 / フォールバック: localStorage 経路
+            hydrateFromPlans(loadFromLocalStorage());
+        };
 
-            setStudyPlan(active);
-        }
+        run();
 
         // Check query param for replan trigger
         const params = new URLSearchParams(window.location.search);
@@ -190,7 +205,9 @@ export default function DashboardClient() {
             setShowWizard(true);
             window.history.replaceState({}, '', '/dashboard');
         }
-    }, []);
+
+        return () => { cancelled = true; };
+    }, [status, session?.user?.id]);
 
     // 2.5. Check for pending completed jobs (async job notification)
     useEffect(() => {
@@ -246,19 +263,15 @@ export default function DashboardClient() {
         const allPlansStr = localStorage.getItem('studyPlans');
         let allPlans: StudyPlan[] = allPlansStr ? JSON.parse(allPlansStr) : [];
 
-        // Check if updating existing (by ID) -- though Wizard generates NEW ID currently. 
-        // If we want to support "Edit", we need to pass ID to Wizard. 
-        // For Re-plan, we usually Replace or Add New. 
-        // If "Re-plan" means "Update schedule for same exam", maybe we should remove old one?
-        // Let's just append for now to be safe (History). User can delete later.
-        // Wait, if 10 re-plans, array grows. 
-        // Better: Remove any existing plan for the SAME examId and SAME examDate? 
-        // Or just by ID if updating.
-
-        // Current Wizard generates NEW ID every time. 
-        // Let's Append.
+        // Current Wizard generates NEW ID every time. Append for history.
         allPlans.push(plan);
         localStorage.setItem('studyPlans', JSON.stringify(allPlans));
+        setAllPlans(allPlans);
+
+        // Server 永続化 (#212): 認証済みなら best-effort で upsert
+        if (status === 'authenticated') {
+            upsertStudyPlan(plan).catch(() => {});
+        }
 
         setShowWizard(false);
     };
@@ -484,6 +497,10 @@ export default function DashboardClient() {
             setAllPlans(updatedPlans);
             const refreshed = updatedPlans.find(plan => plan.id === studyPlan.id) || studyPlan;
             setStudyPlan(refreshed);
+            // #212: server にも反映（best-effort）
+            if (status === 'authenticated') {
+                upsertStudyPlan(refreshed).catch(() => {});
+            }
         } catch (error) {
             console.error("Failed to update studyPlans completion state", error);
         }

--- a/apps/web/components/features/plan/PlanViewer.tsx
+++ b/apps/web/components/features/plan/PlanViewer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import type { StudyPlan } from '@/lib/types/studyPlan';
-import { LearningRecord, getLearningRecords } from '@/lib/api';
+import { LearningRecord, getLearningRecords, listStudyPlans, upsertStudyPlan, deleteStudyPlan, migrateLocalStudyPlansToServer } from '@/lib/api';
 import { guestManager } from '@/lib/guest-manager';
 import Link from 'next/link';
 import PlanEditor from '@/components/features/study-plan/PlanEditor';
@@ -15,36 +15,55 @@ export default function PlanViewer() {
     const [dailyCounts, setDailyCounts] = useState<Record<string, number>>({});
     const [editing, setEditing] = useState(false);
 
-    // 1. Load Plans
+    // 1. Load Plans (#212: server-first when authenticated)
     useEffect(() => {
-        const savedPlansStr = localStorage.getItem('studyPlans');
-        let loadedPlans: StudyPlan[] = [];
+        let cancelled = false;
 
-        if (savedPlansStr) {
-            try {
-                loadedPlans = JSON.parse(savedPlansStr);
-            } catch (e) { console.error(e); }
-        } else {
-            // Legacy fallback
+        const loadFromLocalStorage = (): StudyPlan[] => {
+            const savedPlansStr = localStorage.getItem('studyPlans');
+            if (savedPlansStr) {
+                try { return JSON.parse(savedPlansStr); } catch (e) { console.error(e); }
+            }
             const legacy = localStorage.getItem('studyPlan');
             if (legacy) {
                 try {
                     const p = JSON.parse(legacy);
                     if (!p.id) p.id = 'legacy';
-                    loadedPlans = [p];
-                } catch (e) { }
+                    return [p];
+                } catch { /* noop */ }
             }
-        }
+            return [];
+        };
 
-        setPlans(loadedPlans);
-        if (loadedPlans.length > 0) {
-            // Default to nearest future or last
-            const sorted = [...loadedPlans].sort((a, b) => new Date(a.examDate).getTime() - new Date(b.examDate).getTime());
-            const future = sorted.filter(p => new Date(p.examDate) >= new Date(new Date().setHours(0, 0, 0, 0)));
-            const active = future.length > 0 ? future[0] : sorted[sorted.length - 1];
-            setSelectedPlanId(active.id);
-        }
-    }, []);
+        const apply = (loadedPlans: StudyPlan[]) => {
+            if (cancelled) return;
+            setPlans(loadedPlans);
+            if (loadedPlans.length > 0) {
+                const sorted = [...loadedPlans].sort((a, b) => new Date(a.examDate).getTime() - new Date(b.examDate).getTime());
+                const future = sorted.filter(p => new Date(p.examDate) >= new Date(new Date().setHours(0, 0, 0, 0)));
+                const active = future.length > 0 ? future[0] : sorted[sorted.length - 1];
+                setSelectedPlanId(active.id);
+            }
+        };
+
+        const run = async () => {
+            if (status === 'authenticated' && session?.user?.id) {
+                await migrateLocalStudyPlansToServer(session.user.id);
+                const fromServer = await listStudyPlans();
+                if (cancelled) return;
+                if (fromServer) {
+                    localStorage.setItem('studyPlans', JSON.stringify(fromServer));
+                    apply(fromServer);
+                    return;
+                }
+            }
+            apply(loadFromLocalStorage());
+        };
+
+        if (status !== 'loading') run();
+
+        return () => { cancelled = true; };
+    }, [status, session?.user?.id]);
 
     // 2. Load Progress Records
     useEffect(() => {
@@ -85,12 +104,18 @@ export default function PlanViewer() {
         if (selectedPlanId === id) {
             setSelectedPlanId(newPlans.length > 0 ? newPlans[0].id : null);
         }
+        if (status === 'authenticated') {
+            deleteStudyPlan(id).catch(() => {});
+        }
     };
 
     const handleUpdatePlan = (updatedPlan: StudyPlan) => {
         const newPlans = plans.map(p => p.id === updatedPlan.id ? updatedPlan : p);
         setPlans(newPlans);
         localStorage.setItem('studyPlans', JSON.stringify(newPlans));
+        if (status === 'authenticated') {
+            upsertStudyPlan(updatedPlan).catch(() => {});
+        }
     };
 
     /** PlanEditor からの「適用」を受けて、現在選択中の plan を更新する */

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -444,3 +444,99 @@ export async function getLatestStudyPlanJob(userId: string): Promise<StudyPlanJo
         return null;
     }
 }
+
+// --- Study Plan Persistence (#212) ---
+
+/**
+ * 認証ユーザーの学習計画一覧を取得。
+ * 401 / ネットワークエラー時は null を返す（呼び出し側で localStorage へフォールバック）。
+ */
+export async function listStudyPlans(): Promise<StudyPlan[] | null> {
+    try {
+        const res = await fetch(`${API_BASE}/study-plan`, { cache: 'no-store' });
+        if (res.status === 401) return null;
+        if (!res.ok) throw new Error(res.statusText);
+        return (await res.json()) as StudyPlan[];
+    } catch (e) {
+        console.warn('listStudyPlans failed (falling back to localStorage):', e);
+        return null;
+    }
+}
+
+/** 単一計画を upsert (PUT)。失敗時は null。 */
+export async function upsertStudyPlan(plan: StudyPlan): Promise<StudyPlan | null> {
+    try {
+        const res = await fetch(`${API_BASE}/study-plan/${encodeURIComponent(plan.id)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(plan),
+        });
+        if (!res.ok) throw new Error(`PUT failed: ${res.status}`);
+        return (await res.json()) as StudyPlan;
+    } catch (e) {
+        console.warn('upsertStudyPlan failed:', e);
+        return null;
+    }
+}
+
+/** 計画削除。サーバ側に存在しなくても true を返す。 */
+export async function deleteStudyPlan(id: string): Promise<boolean> {
+    try {
+        const res = await fetch(`${API_BASE}/study-plan/${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+        });
+        return res.ok || res.status === 404;
+    } catch (e) {
+        console.warn('deleteStudyPlan failed:', e);
+        return false;
+    }
+}
+
+/**
+ * localStorage の `studyPlans` をサーバへ一括移行。
+ * 一度成功したら `studyPlans:migratedFor:<userId>` フラグを立てて二度走らない。
+ *
+ * @returns 移行件数。スキップ時は -1。
+ */
+export async function migrateLocalStudyPlansToServer(userId: string): Promise<number> {
+    if (typeof window === 'undefined') return -1;
+    const flagKey = `studyPlans:migratedFor:${userId}`;
+    if (localStorage.getItem(flagKey)) return -1;
+
+    const raw = localStorage.getItem('studyPlans');
+    if (!raw) {
+        localStorage.setItem(flagKey, new Date().toISOString());
+        return 0;
+    }
+
+    let plans: StudyPlan[] = [];
+    try {
+        plans = JSON.parse(raw);
+    } catch {
+        return -1;
+    }
+    if (!Array.isArray(plans) || plans.length === 0) {
+        localStorage.setItem(flagKey, new Date().toISOString());
+        return 0;
+    }
+
+    // id 欠落データを補正
+    const normalized = plans.map((p) =>
+        p.id ? p : { ...p, id: typeof crypto !== 'undefined' ? crypto.randomUUID() : `legacy-${Date.now()}` },
+    );
+
+    try {
+        const res = await fetch(`${API_BASE}/study-plan`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(normalized),
+        });
+        if (!res.ok) throw new Error(`migrate POST failed: ${res.status}`);
+        const data = await res.json();
+        localStorage.setItem(flagKey, new Date().toISOString());
+        return typeof data?.count === 'number' ? data.count : normalized.length;
+    } catch (e) {
+        console.warn('migrateLocalStudyPlansToServer failed:', e);
+        return -1;
+    }
+}

--- a/apps/web/lib/cosmos.ts
+++ b/apps/web/lib/cosmos.ts
@@ -11,6 +11,7 @@ const CONTAINER_PARTITION_KEYS: Record<string, string> = {
     LearningRecords: "/userId",
     LearningSessions: "/userId",
     DailyProgress: "/userId",
+    StudyPlan: "/userId",
     Exams: "/id",
     ExamProgress: "/userId",
     Metrics: "/type",

--- a/apps/web/lib/repositories/studyPlanRepository.ts
+++ b/apps/web/lib/repositories/studyPlanRepository.ts
@@ -1,0 +1,80 @@
+import { getContainer } from '@/lib/cosmos';
+import type { SqlQuerySpec } from '@azure/cosmos';
+import { StoredStudyPlanSchema, type StoredStudyPlan } from '@/lib/types/studyPlanSchema';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+
+/**
+ * 学習計画リポジトリ (#212)
+ *
+ * - Container: `StudyPlan`
+ * - PartitionKey: `/userId`
+ * - id: クライアント側で `crypto.randomUUID()` 生成済みのものを利用
+ *
+ * 本リポジトリは Server Component / Route Handler からのみ呼ばれる前提。
+ * 認可は呼び出し側（Route Handler）で `session.user.id` を userId として渡すこと。
+ */
+export const studyPlanRepository = {
+    containerName: 'StudyPlan',
+
+    async listByUser(userId: string): Promise<StudyPlan[]> {
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        const querySpec: SqlQuerySpec = {
+            query: 'SELECT * FROM c WHERE c.userId = @userId ORDER BY c.examDate ASC',
+            parameters: [{ name: '@userId', value: userId }],
+        };
+        const { resources } = await container.items.query(querySpec).fetchAll();
+        return (resources as StoredStudyPlan[]).map(stripUserId);
+    },
+
+    async findById(userId: string, id: string): Promise<StudyPlan | null> {
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        try {
+            const { resource } = await container.item(id, userId).read<StoredStudyPlan>();
+            return resource ? stripUserId(resource) : null;
+        } catch (err: unknown) {
+            const e = err as { code?: number; statusCode?: number };
+            if (e?.code === 404 || e?.statusCode === 404) return null;
+            throw err;
+        }
+    },
+
+    async upsert(userId: string, plan: StudyPlan): Promise<StudyPlan> {
+        const stored = StoredStudyPlanSchema.parse({ ...plan, userId });
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        const { resource } = await container.items.upsert(stored);
+        if (!resource) throw new Error('Failed to upsert study plan');
+        return stripUserId(resource as unknown as StoredStudyPlan);
+    },
+
+    async upsertMany(userId: string, plans: StudyPlan[]): Promise<number> {
+        if (plans.length === 0) return 0;
+        let n = 0;
+        for (const plan of plans) {
+            await this.upsert(userId, plan);
+            n += 1;
+        }
+        return n;
+    },
+
+    async remove(userId: string, id: string): Promise<boolean> {
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        try {
+            await container.item(id, userId).delete();
+            return true;
+        } catch (err: unknown) {
+            const e = err as { code?: number; statusCode?: number };
+            if (e?.code === 404 || e?.statusCode === 404) return false;
+            throw err;
+        }
+    },
+};
+
+function stripUserId(stored: StoredStudyPlan): StudyPlan {
+    const { userId: _userId, ...rest } = stored;
+    void _userId;
+    return rest as StudyPlan;
+}

--- a/apps/web/lib/types/studyPlanSchema.ts
+++ b/apps/web/lib/types/studyPlanSchema.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+/**
+ * StudyPlan の Zod スキーマ。
+ * `lib/types/studyPlan.ts` の TS 型と整合している必要がある。
+ *
+ * #212 で API 永続化用に追加。
+ * - dailyTasks は legacy データ（未生成週）で undefined もありえるため optional
+ * - id は Cosmos の docID と一致（partitionKey は /userId）
+ */
+
+export const DailyTaskSchema = z.object({
+    date: z.string(),
+    missionTitle: z.string().optional(),
+    goal: z.string(),
+    questionCount: z.number(),
+    targetCategory: z.string().optional(),
+    targetExamId: z.string().optional(),
+    difficulty: z.enum(['easy', 'normal', 'hard']).optional(),
+    xpReward: z.number().optional(),
+    isCompleted: z.boolean().optional(),
+});
+
+export const WeeklyScheduleItemSchema = z.object({
+    weekNumber: z.number(),
+    startDate: z.string(),
+    endDate: z.string(),
+    theme: z.string().optional(),
+    goal: z.string(),
+    focus: z.string().optional(),
+    dailyTasks: z.array(DailyTaskSchema).optional().default([]),
+});
+
+export const MonthlyGoalSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    type: z.enum(['questionCount', 'accuracy', 'studyDays', 'correctCount', 'custom']),
+    targetValue: z.number(),
+    unit: z.string(),
+    iconEmoji: z.string(),
+});
+
+export const StudyPlanSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+    targetExam: z.string().optional(),
+    examDate: z.string(),
+    hoursWeekday: z.number().optional(),
+    hoursWeekend: z.number().optional(),
+    monthlyGoal: z.string(),
+    monthlyGoals: z.array(MonthlyGoalSchema).optional(),
+    weeklySchedule: z.array(WeeklyScheduleItemSchema),
+    generatedAt: z.string(),
+    totalXpEarned: z.number().optional(),
+});
+
+/** Cosmos に保存する内部表現 (userId を付与) */
+export const StoredStudyPlanSchema = StudyPlanSchema.extend({
+    userId: z.string(),
+});
+
+export type StoredStudyPlan = z.infer<typeof StoredStudyPlanSchema>;

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #212

## 概要
学習計画 (StudyPlan) を Cosmos DB に永続化し、複数端末・再ログイン後も計画が引き継がれるようにします。既存の localStorage データはログイン時に自動でサーバへマイグレーションされます。

## 変更内容

### サーバ
- `lib/cosmos.ts`: `StudyPlan` コンテナを `CONTAINER_PARTITION_KEYS` に追加 (PK: `/userId`)
- `lib/types/studyPlanSchema.ts` (新規): Zod スキーマで型安全性を担保
- `lib/repositories/studyPlanRepository.ts` (新規): `listByUser` / `findById` / `upsert` / `upsertMany` / `remove`
- `app/api/study-plan/route.ts` (新規): `GET` 一覧 / `POST` upsert (単件 or 配列 = マイグレーション用)
- `app/api/study-plan/[id]/route.ts` (新規): `GET` / `PUT` / `DELETE`

### クライアント
- `lib/api.ts`: `listStudyPlans` / `upsertStudyPlan` / `deleteStudyPlan` / `migrateLocalStudyPlansToServer`
- `DashboardClient.tsx`: server-first 読込 + auth-aware マイグレーション。`handleSavePlan` とミッション完了時に `upsertStudyPlan` を呼び出し
- `PlanViewer.tsx`: server-first 読込 + マイグレーション。`handleDelete` / `handleUpdatePlan` でサーバへ反映

## 設計メモ
- **server-first + localStorage フォールバック**: 認証済みユーザーはサーバを正本とし、API 失敗時は localStorage にフォールバック。localStorage は常に同期更新するためオフライン耐性を維持
- **マイグレーションは idempotent**: `studyPlans:migratedFor:<userId>` フラグで二度走らない。失敗時はフラグを立てない (リトライ可能)
- **best-effort writes**: サーバ書き込み失敗時は localStorage が既に更新済みなので UX を阻害しない
- **信頼境界**: API ルートは `session.user.id` のみを信頼し、リクエスト中の userId は無視
- **PUT は body.id === path id を強制** (400)

## テスト
- 新規 19 件すべてパス (API 13 / Repository 6)
- 既存テストを含む全 557 件 / 46 ファイル green
- `npm run build` 成功

## 動作確認手順
1. 未ログインで計画作成 → localStorage に保存
2. ログイン → サーバへ自動マイグレーション
3. 別端末でログイン → 計画が表示される
4. 計画を編集/削除 → 双方端末でリロードしても反映されている

## 関連
- #214 の防御深化と整合 (`weeklySchedule.dailyTasks` の optional 許容)
- #211 (D&D) は次の PR で対応予定