### PR TITLE
feat(#211): タスク単位 D&D 移動 (replan v1.5 + 編集UI Phase 2)

### DIFF
--- a/apps/web/__tests__/lib/editorState.test.ts
+++ b/apps/web/__tests__/lib/editorState.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+    EMPTY_EDITOR_STATE,
+    setMode,
+    setMove,
+    clearMove,
+    hasAnyEdit,
+    manualMovesFromState,
+} from '@/lib/study-plan/editorState';
+
+describe('editorState', () => {
+    it('setMode: normal なら entry を削除', () => {
+        const s1 = setMode(EMPTY_EDITOR_STATE, '2026-04-22', 'rest');
+        expect(s1.modes['2026-04-22']).toBe('rest');
+        const s2 = setMode(s1, '2026-04-22', 'normal');
+        expect(s2.modes['2026-04-22']).toBeUndefined();
+    });
+
+    it('setMove: from === to なら clearMove と等価', () => {
+        const s1 = setMove(EMPTY_EDITOR_STATE, '2026-04-22', '2026-04-23');
+        expect(s1.moves['2026-04-22']).toBe('2026-04-23');
+        const s2 = setMove(s1, '2026-04-22', '2026-04-22');
+        expect(s2.moves['2026-04-22']).toBeUndefined();
+    });
+
+    it('clearMove: 指定 fromDate を消す', () => {
+        const s1 = setMove(EMPTY_EDITOR_STATE, '2026-04-22', '2026-04-23');
+        const s2 = clearMove(s1, '2026-04-22');
+        expect(s2.moves['2026-04-22']).toBeUndefined();
+    });
+
+    it('hasAnyEdit: modes か moves に何かあれば true', () => {
+        expect(hasAnyEdit(EMPTY_EDITOR_STATE)).toBe(false);
+        expect(hasAnyEdit(setMode(EMPTY_EDITOR_STATE, 'd', 'rest'))).toBe(true);
+        expect(hasAnyEdit(setMove(EMPTY_EDITOR_STATE, 'a', 'b'))).toBe(true);
+    });
+
+    it('manualMovesFromState: { from, to }[] に変換', () => {
+        const s = setMove(setMove(EMPTY_EDITOR_STATE, 'a', 'b'), 'c', 'd');
+        const moves = manualMovesFromState(s);
+        expect(moves).toContainEqual({ fromDate: 'a', toDate: 'b' });
+        expect(moves).toContainEqual({ fromDate: 'c', toDate: 'd' });
+        expect(moves).toHaveLength(2);
+    });
+
+    it('immutability: 元の state は変更されない', () => {
+        const s1 = EMPTY_EDITOR_STATE;
+        const s2 = setMode(s1, '2026-04-22', 'rest');
+        expect(s1.modes['2026-04-22']).toBeUndefined();
+        expect(s2).not.toBe(s1);
+    });
+});

--- a/apps/web/__tests__/lib/replan.v15.test.ts
+++ b/apps/web/__tests__/lib/replan.v15.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { replan } from '@/lib/plan/replan';
+import type { StudyPlan } from '@/lib/api';
+
+const NOW = '2026-04-21T00:00:00.000Z';
+const now = () => NOW;
+
+const buildPlan = (
+    days: { date: string; questionCount: number }[],
+    examDate = '2026-05-01',
+): StudyPlan => ({
+    title: 'test plan',
+    examDate,
+    monthlyGoal: 'goal',
+    weeklySchedule: [
+        {
+            weekNumber: 1,
+            startDate: days[0]?.date ?? '2026-04-15',
+            endDate: days[days.length - 1]?.date ?? '2026-04-30',
+            goal: 'w1',
+            dailyTasks: days.map((d) => ({
+                date: d.date,
+                goal: 'g',
+                questionCount: d.questionCount,
+            })),
+        },
+    ],
+    generatedAt: NOW,
+});
+
+describe('replan v1.5: manualMoves', () => {
+    it('manualMoves で from の問題数を to に転送し、from は 0 になる', () => {
+        const plan = buildPlan([
+            { date: '2026-04-22', questionCount: 10 },
+            { date: '2026-04-23', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [],
+            today: '2026-04-21',
+            manualMoves: [{ fromDate: '2026-04-22', toDate: '2026-04-23' }],
+            options: { now },
+        });
+        expect(r.algorithmVersion).toBe('1.5');
+        expect(r.diff.manualMovesApplied).toBe(1);
+        expect(r.plan.weeklySchedule[0].dailyTasks[0].questionCount).toBe(0);
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(15);
+        const move = r.diff.moved.find((m) => m.reason === 'manual_move');
+        expect(move).toEqual({
+            fromDate: '2026-04-22',
+            toDate: '2026-04-23',
+            questionCount: 10,
+            reason: 'manual_move',
+        });
+    });
+
+    it('manualMoves が空配列なら v1.0 と同じ挙動', () => {
+        const plan = buildPlan([
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-23', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [],
+            today: '2026-04-21',
+            manualMoves: [],
+            options: { now },
+        });
+        expect(r.algorithmVersion).toBe('1.0');
+        expect(r.diff.manualMovesApplied).toBe(0);
+    });
+
+    it('過去日への移動は overflowed に記録される', () => {
+        const plan = buildPlan([
+            { date: '2026-04-22', questionCount: 10 },
+            { date: '2026-04-23', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [],
+            today: '2026-04-21',
+            manualMoves: [{ fromDate: '2026-04-22', toDate: '2026-04-19' }],
+            options: { now },
+        });
+        const inv = r.diff.overflowed.find((o) => o.reason === 'manual_move_invalid');
+        expect(inv).toBeDefined();
+        expect(inv?.questionCount).toBe(10);
+    });
+
+    it('複数 manualMoves を順次適用できる', () => {
+        const plan = buildPlan([
+            { date: '2026-04-22', questionCount: 10 },
+            { date: '2026-04-23', questionCount: 5 },
+            { date: '2026-04-24', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [],
+            today: '2026-04-21',
+            manualMoves: [
+                { fromDate: '2026-04-22', toDate: '2026-04-24' },
+                { fromDate: '2026-04-23', toDate: '2026-04-24' },
+            ],
+            options: { now },
+        });
+        expect(r.diff.manualMovesApplied).toBe(2);
+        expect(r.plan.weeklySchedule[0].dailyTasks[0].questionCount).toBe(0);
+        expect(r.plan.weeklySchedule[0].dailyTasks[1].questionCount).toBe(0);
+        expect(r.plan.weeklySchedule[0].dailyTasks[2].questionCount).toBe(20);
+    });
+
+    it('manualMoves の後で過去 debt も再配分される (combined)', () => {
+        const plan = buildPlan([
+            { date: '2026-04-19', questionCount: 10 },
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-23', questionCount: 5 },
+        ]);
+        const r = replan({
+            plan,
+            dailyProgress: [],
+            today: '2026-04-21',
+            manualMoves: [{ fromDate: '2026-04-22', toDate: '2026-04-23' }],
+            options: { now },
+        });
+        // manual move: 5 -> 23 (now 10), 22 -> 0
+        // past debt: 10 questions from 04-19, redistribute to future days
+        expect(r.diff.manualMovesApplied).toBe(1);
+        expect(r.diff.totalDebtQuestions).toBe(10);
+    });
+
+    it('fromDate === toDate の move は無視される', () => {
+        const plan = buildPlan([{ date: '2026-04-22', questionCount: 10 }]);
+        const r = replan({
+            plan,
+            dailyProgress: [],
+            today: '2026-04-21',
+            manualMoves: [{ fromDate: '2026-04-22', toDate: '2026-04-22' }],
+            options: { now },
+        });
+        expect(r.diff.manualMovesApplied).toBe(0);
+        // overflowed 'manual_move_invalid' は記録される (qty > 0)
+        expect(r.diff.overflowed.some((o) => o.reason === 'manual_move_invalid')).toBe(true);
+    });
+});

--- a/apps/web/app/api/study-plan/replan/route.ts
+++ b/apps/web/app/api/study-plan/replan/route.ts
@@ -62,9 +62,15 @@ const StudyPlanShape = z
     })
     .passthrough();
 
+const ManualMoveSchema = z.object({
+    fromDate: DateString,
+    toDate: DateString,
+});
+
 const BodySchema = z.object({
     plan: StudyPlanShape,
     today: DateString.optional(),
+    manualMoves: z.array(ManualMoveSchema).optional(),
 });
 
 function todayUtc(): string {
@@ -107,7 +113,7 @@ export async function POST(request: NextRequest) {
             to: today,
         });
 
-        const result = replan({ plan, dailyProgress, today });
+        const result = replan({ plan, dailyProgress, today, manualMoves: parsed.data.manualMoves });
         return NextResponse.json(result);
     } catch (e) {
         const message = e instanceof Error ? e.message : 'Internal Error';

--- a/apps/web/components/features/study-plan/PlanEditor.module.css
+++ b/apps/web/components/features/study-plan/PlanEditor.module.css
@@ -244,6 +244,38 @@
     border: 1px solid #e5e7eb;
 }
 
+.cellDragOver {
+    background: #dbeafe;
+    border-color: #2563eb;
+    border-style: dashed;
+}
+
+.cellDragging {
+    opacity: 0.4;
+}
+
+.moveButton {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    padding: 1px 4px;
+    font-size: 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.9);
+    cursor: pointer;
+    line-height: 1;
+}
+
+.moveButton:hover {
+    background: #eff6ff;
+    border-color: #2563eb;
+}
+
+.cell {
+    position: relative;
+}
+
 @media (max-width: 480px) {
     .cell {
         min-height: 60px;

--- a/apps/web/components/features/study-plan/PlanEditor.tsx
+++ b/apps/web/components/features/study-plan/PlanEditor.tsx
@@ -1,26 +1,37 @@
 'use client';
 
 /**
- * StudyPlan 編集UI Phase 1 (#189)
+ * StudyPlan 編集UI (#189 Phase 1 + #211 Phase 2)
  *
- * - カレンダー上のセルをクリック → 通常 / 休 / 集 をローテーション切替
- * - トグルが入るたびに `applyEditState` で plan を書き換え、
- *   `POST /api/study-plan/replan` を呼んで diff プレビュー表示
- * - 「適用」で localStorage('studyPlans') を更新（リロード後も維持）
+ * Phase 1: カレンダー上のセルをクリック → 通常 / 休 / 集 をローテーション切替
+ * Phase 2 (#211): タスクを D&D で別日へ移動。a11y フォールバックとして「移動」ボタン
+ *                 → 日付選択ダイアログを提供。
+ *
+ * - 編集が入るたびに `applyEditState` で plan を書き換え、
+ *   `POST /api/study-plan/replan` を `manualMoves` 付きで呼んで diff プレビュー
+ * - 「適用」で localStorage('studyPlans') / サーバを更新
  * - Undo/Redo は最大 5 ステップ、Ctrl+Z / Ctrl+Shift+Z 対応
  *
  * 設計書: docs/02_design/21_StudyPlanEditUI.md
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './PlanEditor.module.css';
 import {
     applyEditState,
     cycleEditMode,
     listAllDates,
     type EditMode,
-    type EditState,
 } from '@/lib/study-plan/planEditActions';
+import {
+    EMPTY_EDITOR_STATE,
+    hasAnyEdit,
+    manualMovesFromState,
+    setMode,
+    setMove,
+    clearMove,
+    type EditorState,
+} from '@/lib/study-plan/editorState';
 import { useUndoRedo } from '@/lib/study-plan/useUndoRedo';
 import type { StudyPlan, DailyTask } from '@/lib/types/studyPlan';
 
@@ -31,6 +42,7 @@ interface ReplanResult {
         overflowed: { fromDate: string; questionCount: number; reason: string }[];
         totalDebtQuestions: number;
         redistributedQuestions: number;
+        manualMovesApplied?: number;
     };
     warnings?: string[];
 }
@@ -66,10 +78,10 @@ function buildCalendarDates(allDates: string[]): string[] {
     const last = new Date(`${allDates[allDates.length - 1]}T00:00:00Z`);
 
     const start = new Date(first);
-    start.setUTCDate(start.getUTCDate() - start.getUTCDay()); // back to Sunday
+    start.setUTCDate(start.getUTCDate() - start.getUTCDay());
 
     const end = new Date(last);
-    end.setUTCDate(end.getUTCDate() + (6 - end.getUTCDay())); // forward to Saturday
+    end.setUTCDate(end.getUTCDate() + (6 - end.getUTCDay()));
 
     const result: string[] = [];
     const cur = new Date(start);
@@ -85,34 +97,94 @@ function buildCalendarDates(allDates: string[]): string[] {
 }
 
 export default function PlanEditor({ plan, onApply, onCancel }: Props) {
-    const editHistory = useUndoRedo<EditState>({});
-    const edits = editHistory.present;
+    const editHistory = useUndoRedo<EditorState>(EMPTY_EDITOR_STATE);
+    const editor = editHistory.present;
 
     const [preview, setPreview] = useState<ReplanResult | null>(null);
     const [previewing, setPreviewing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [showModal, setShowModal] = useState(false);
+    const [draggingDate, setDraggingDate] = useState<string | null>(null);
+    const [dragOverDate, setDragOverDate] = useState<string | null>(null);
+    const [moveDialogFor, setMoveDialogFor] = useState<string | null>(null);
+    const moveDialogSelectRef = useRef<HTMLSelectElement | null>(null);
 
     const dateMap = useMemo(() => buildDateMap(plan), [plan]);
     const allDates = useMemo(() => listAllDates(plan), [plan]);
     const calendarDates = useMemo(() => buildCalendarDates(allDates), [allDates]);
 
-    const editedPlan = useMemo(() => applyEditState(plan, edits), [plan, edits]);
+    // 編集後 plan: modes (rest/focus) のみ反映。moves はプレビュー API 側で処理
+    const editedPlan = useMemo(() => applyEditState(plan, editor.modes), [plan, editor.modes]);
 
-    const hasEdits = Object.keys(edits).length > 0;
+    const hasEdits = hasAnyEdit(editor);
 
-    /** トグル: normal -> rest -> focus -> normal */
+    /** モードトグル: normal -> rest -> focus -> normal */
     const handleCellClick = useCallback(
         (date: string) => {
             if (!dateMap.has(date)) return;
-            const next: EditState = { ...edits };
-            const newMode = cycleEditMode(next[date]);
-            if (newMode === 'normal') delete next[date];
-            else next[date] = newMode;
-            editHistory.set(next);
+            const currentMode: EditMode = editor.modes[date] ?? 'normal';
+            const newMode = cycleEditMode(currentMode);
+            editHistory.set(setMode(editor, date, newMode));
         },
-        [dateMap, edits, editHistory],
+        [dateMap, editor, editHistory],
     );
+
+    // --- D&D ハンドラ ----------------------------------------------------------
+    const handleDragStart = useCallback((date: string, e: React.DragEvent) => {
+        if (!dateMap.has(date)) return;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', date);
+        setDraggingDate(date);
+    }, [dateMap]);
+
+    const handleDragEnd = useCallback(() => {
+        setDraggingDate(null);
+        setDragOverDate(null);
+    }, []);
+
+    const handleDragOver = useCallback((date: string, e: React.DragEvent) => {
+        if (!dateMap.has(date)) return;
+        if (draggingDate && draggingDate !== date) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            setDragOverDate(date);
+        }
+    }, [dateMap, draggingDate]);
+
+    const handleDrop = useCallback((date: string, e: React.DragEvent) => {
+        e.preventDefault();
+        const fromDate = e.dataTransfer.getData('text/plain') || draggingDate;
+        setDraggingDate(null);
+        setDragOverDate(null);
+        if (!fromDate || fromDate === date) return;
+        if (!dateMap.has(date) || !dateMap.has(fromDate)) return;
+        editHistory.set(setMove(editor, fromDate, date));
+    }, [dateMap, draggingDate, editor, editHistory]);
+
+    // --- 移動ダイアログ (a11y フォールバック) -----------------------------------
+    const openMoveDialog = useCallback((date: string) => {
+        setMoveDialogFor(date);
+    }, []);
+    const closeMoveDialog = useCallback(() => {
+        setMoveDialogFor(null);
+    }, []);
+    useEffect(() => {
+        if (moveDialogFor && moveDialogSelectRef.current) {
+            moveDialogSelectRef.current.focus();
+        }
+    }, [moveDialogFor]);
+    const confirmMoveDialog = useCallback(() => {
+        if (!moveDialogFor) return;
+        const select = moveDialogSelectRef.current;
+        if (!select) return;
+        const toDate = select.value;
+        if (!toDate || toDate === moveDialogFor) {
+            closeMoveDialog();
+            return;
+        }
+        editHistory.set(setMove(editor, moveDialogFor, toDate));
+        closeMoveDialog();
+    }, [moveDialogFor, editor, editHistory, closeMoveDialog]);
 
     /** プレビュー: replan API 呼び出し */
     const requestPreview = useCallback(async () => {
@@ -122,7 +194,10 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
             const res = await fetch('/api/study-plan/replan', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ plan: editedPlan }),
+                body: JSON.stringify({
+                    plan: editedPlan,
+                    manualMoves: manualMovesFromState(editor),
+                }),
             });
             if (res.status === 401) {
                 throw new Error('プレビューにはログインが必要です');
@@ -139,12 +214,12 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
         } finally {
             setPreviewing(false);
         }
-    }, [editedPlan]);
+    }, [editedPlan, editor]);
 
     const handleApply = useCallback(() => {
         if (!preview) return;
         onApply?.(preview.plan);
-        editHistory.reset({});
+        editHistory.reset(EMPTY_EDITOR_STATE);
         setPreview(null);
         setShowModal(false);
     }, [preview, onApply, editHistory]);
@@ -155,13 +230,18 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
 
     // モーダル: Esc で閉じる
     useEffect(() => {
-        if (!showModal) return;
         const handler = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') setShowModal(false);
+            if (e.key === 'Escape') {
+                if (showModal) setShowModal(false);
+                if (moveDialogFor) closeMoveDialog();
+            }
         };
-        window.addEventListener('keydown', handler);
-        return () => window.removeEventListener('keydown', handler);
-    }, [showModal]);
+        if (showModal || moveDialogFor) {
+            window.addEventListener('keydown', handler);
+            return () => window.removeEventListener('keydown', handler);
+        }
+        return undefined;
+    }, [showModal, moveDialogFor, closeMoveDialog]);
 
     if (allDates.length === 0) {
         return (
@@ -208,7 +288,7 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
                 <button
                     type="button"
                     className={styles.button}
-                    onClick={() => editHistory.reset({})}
+                    onClick={() => editHistory.reset(EMPTY_EDITOR_STATE)}
                     disabled={!hasEdits}
                 >
                     リセット
@@ -244,7 +324,7 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
                     <span className={styles.legendSwatch} style={{ background: '#fef3c7', borderColor: '#fbbf24' }} /> 集中
                 </span>
                 <span style={{ marginLeft: 'auto', color: '#9ca3af' }}>
-                    クリックで切替（通常 → 休 → 集中 → 通常）
+                    クリックで切替 / ドラッグで別日へ移動
                 </span>
             </div>
 
@@ -258,7 +338,7 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
                 ))}
                 {calendarDates.map((date) => {
                     const task = dateMap.get(date);
-                    const mode: EditMode = edits[date] ?? 'normal';
+                    const mode: EditMode = editor.modes[date] ?? 'normal';
                     if (!task) {
                         return <div key={date} className={`${styles.cell} ${styles.cellEmpty}`} aria-hidden="true" />;
                     }
@@ -266,38 +346,163 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
                     const baseline = task.questionCount;
                     const adjusted =
                         mode === 'rest' ? 0 : mode === 'focus' ? Math.round(baseline * 1.5) : baseline;
+                    const movedTo = editor.moves[date];
+                    const isDragging = draggingDate === date;
+                    const isDragOver = dragOverDate === date;
                     const cellClass = [
                         styles.cell,
                         mode === 'rest' ? styles.cellRest : '',
                         mode === 'focus' ? styles.cellFocus : '',
+                        isDragOver ? styles.cellDragOver : '',
+                        isDragging ? styles.cellDragging : '',
                     ]
                         .filter(Boolean)
                         .join(' ');
                     const wd = WEEKDAYS[weekdayIndex(date)];
                     const ariaLabel = `${date} ${wd}曜日、現在 ${adjusted} 問${
                         mode === 'rest' ? '（休日）' : mode === 'focus' ? '（集中日）' : ''
-                    }、クリックで切替`;
+                    }${movedTo ? `、${movedTo} へ移動予定` : ''}、クリックで切替、移動ボタンで別日へ移動`;
                     return (
-                        <button
+                        <div
                             key={date}
-                            type="button"
                             className={cellClass}
-                            onClick={() => handleCellClick(date)}
-                            aria-label={ariaLabel}
-                            aria-pressed={mode !== 'normal'}
+                            role="gridcell"
+                            draggable
+                            onDragStart={(e) => handleDragStart(date, e)}
+                            onDragEnd={handleDragEnd}
+                            onDragOver={(e) => handleDragOver(date, e)}
+                            onDragLeave={() => setDragOverDate(null)}
+                            onDrop={(e) => handleDrop(date, e)}
                         >
-                            <span className={styles.cellDate}>{dayNum}日 ({wd})</span>
-                            <span className={styles.cellCount}>{adjusted} 問</span>
-                            {mode === 'rest' && (
-                                <span className={`${styles.cellMode} ${styles.cellModeRest}`}>休日</span>
+                            <button
+                                type="button"
+                                className={styles.moveButton}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    openMoveDialog(date);
+                                }}
+                                aria-label={`${date} のタスクを別日へ移動`}
+                            >
+                                移動
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleCellClick(date)}
+                                aria-label={ariaLabel}
+                                aria-pressed={mode !== 'normal'}
+                                style={{
+                                    flex: 1,
+                                    background: 'transparent',
+                                    border: 'none',
+                                    textAlign: 'left',
+                                    cursor: 'pointer',
+                                    padding: 0,
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    gap: '4px',
+                                }}
+                            >
+                                <span className={styles.cellDate}>{dayNum}日 ({wd})</span>
+                                <span className={styles.cellCount}>{adjusted} 問</span>
+                                {mode === 'rest' && (
+                                    <span className={`${styles.cellMode} ${styles.cellModeRest}`}>休日</span>
+                                )}
+                                {mode === 'focus' && (
+                                    <span className={`${styles.cellMode} ${styles.cellModeFocus}`}>集中</span>
+                                )}
+                                {movedTo && (
+                                    <span className={styles.cellMode} style={{ color: '#1d4ed8' }}>
+                                        → {movedTo.slice(5)}
+                                    </span>
+                                )}
+                            </button>
+                            {movedTo && (
+                                <button
+                                    type="button"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        editHistory.set(clearMove(editor, date));
+                                    }}
+                                    aria-label={`${date} の移動をキャンセル`}
+                                    style={{
+                                        position: 'absolute',
+                                        bottom: 2,
+                                        right: 2,
+                                        fontSize: 10,
+                                        padding: '1px 4px',
+                                        border: '1px solid #d1d5db',
+                                        borderRadius: 3,
+                                        background: 'rgba(255,255,255,0.9)',
+                                        cursor: 'pointer',
+                                        lineHeight: 1,
+                                    }}
+                                >
+                                    取消
+                                </button>
                             )}
-                            {mode === 'focus' && (
-                                <span className={`${styles.cellMode} ${styles.cellModeFocus}`}>集中</span>
-                            )}
-                        </button>
+                        </div>
                     );
                 })}
             </div>
+
+            {moveDialogFor && (
+                <div
+                    className={styles.modalBackdrop}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="move-dialog-title"
+                    onClick={closeMoveDialog}
+                >
+                    <div className={styles.modal} onClick={(e) => e.stopPropagation()} style={{ maxWidth: 420 }}>
+                        <div className={styles.modalHeader}>
+                            <h3 id="move-dialog-title" className={styles.modalTitle}>
+                                タスク移動: {moveDialogFor}
+                            </h3>
+                        </div>
+                        <p style={{ fontSize: 13, color: '#374151' }}>
+                            この日のタスクを移動する先の日付を選択してください。
+                        </p>
+                        <label style={{ display: 'block', marginTop: 12 }}>
+                            <span style={{ fontSize: 12, color: '#6b7280' }}>移動先</span>
+                            <select
+                                ref={moveDialogSelectRef}
+                                defaultValue={editor.moves[moveDialogFor] ?? ''}
+                                style={{
+                                    display: 'block',
+                                    width: '100%',
+                                    marginTop: 4,
+                                    padding: '6px 8px',
+                                    fontSize: 14,
+                                    borderRadius: 6,
+                                    border: '1px solid #d1d5db',
+                                }}
+                                aria-label="移動先の日付"
+                            >
+                                <option value="">選択してください</option>
+                                {allDates
+                                    .filter((d) => d !== moveDialogFor)
+                                    .map((d) => (
+                                        <option key={d} value={d}>
+                                            {d} ({WEEKDAYS[weekdayIndex(d)]})
+                                        </option>
+                                    ))}
+                            </select>
+                        </label>
+                        <div className={styles.modalActions}>
+                            <button type="button" className={styles.button} onClick={closeMoveDialog}>
+                                キャンセル
+                            </button>
+                            <button
+                                type="button"
+                                className={`${styles.button} ${styles.primary}`}
+                                onClick={confirmMoveDialog}
+                            >
+                                移動する
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {showModal && preview && (
                 <div
@@ -328,6 +533,11 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
                         <div className={styles.diffSection}>
                             <div className={styles.diffSectionTitle}>
                                 総再配分量: {preview.diff.redistributedQuestions} / {preview.diff.totalDebtQuestions} 問
+                                {preview.diff.manualMovesApplied !== undefined && preview.diff.manualMovesApplied > 0 && (
+                                    <span style={{ marginLeft: 12, color: '#1d4ed8' }}>
+                                        手動移動: {preview.diff.manualMovesApplied} 件
+                                    </span>
+                                )}
                             </div>
                         </div>
 
@@ -338,6 +548,11 @@ export default function PlanEditor({ plan, onApply, onCancel }: Props) {
                                     {preview.diff.moved.slice(0, 30).map((m, i) => (
                                         <li key={i}>
                                             {m.fromDate} → {m.toDate}: {m.questionCount} 問
+                                            {m.reason === 'manual_move' && (
+                                                <span style={{ marginLeft: 8, color: '#1d4ed8', fontSize: 11 }}>
+                                                    [手動]
+                                                </span>
+                                            )}
                                         </li>
                                     ))}
                                     {preview.diff.moved.length > 30 && (

--- a/apps/web/lib/plan/replan.ts
+++ b/apps/web/lib/plan/replan.ts
@@ -30,13 +30,13 @@ export interface ReplanMove {
     fromDate: string;
     toDate: string;
     questionCount: number;
-    reason: 'unfulfilled_carry_forward' | 'capacity_overflow_pushed';
+    reason: 'unfulfilled_carry_forward' | 'capacity_overflow_pushed' | 'manual_move';
 }
 
 export interface ReplanOverflow {
     fromDate: string;
     questionCount: number;
-    reason: 'no_future_capacity' | 'past_exam_date';
+    reason: 'no_future_capacity' | 'past_exam_date' | 'manual_move_invalid';
 }
 
 export interface ReplanDiff {
@@ -44,6 +44,8 @@ export interface ReplanDiff {
     overflowed: ReplanOverflow[];
     totalDebtQuestions: number;
     redistributedQuestions: number;
+    /** v1.5: manualMoves で適用された件数 */
+    manualMovesApplied?: number;
 }
 
 export interface ReplanResult {
@@ -51,7 +53,17 @@ export interface ReplanResult {
     diff: ReplanDiff;
     warnings: string[];
     generatedAt: string;
-    algorithmVersion: '1.0';
+    algorithmVersion: '1.0' | '1.5';
+}
+
+/**
+ * v1.5: ユーザが D&D / 移動ボタンで指示した「タスク単位の移動」。
+ * fromDate / toDate はいずれも `today` 以降かつ `examDate` 以前である必要がある。
+ * 不正な move は overflowed (reason: 'manual_move_invalid') として返却される。
+ */
+export interface ManualMove {
+    fromDate: string;
+    toDate: string;
 }
 
 export interface ReplanInput {
@@ -60,6 +72,8 @@ export interface ReplanInput {
     dailyProgress: DailyProgress[];
     /** 今日の日付 YYYY-MM-DD (UTC)。 */
     today: string;
+    /** v1.5: タスク単位の手動移動指示。空配列または未指定なら v1.0 と同等の挙動 */
+    manualMoves?: ManualMove[];
     options?: ReplanOptions;
 }
 
@@ -76,6 +90,7 @@ export function replan(input: ReplanInput): ReplanResult {
     const opts = { ...DEFAULT_OPTS, ...(input.options ?? {}) };
     const now = (input.options?.now ?? (() => new Date().toISOString()))();
     const { plan, dailyProgress, today } = input;
+    const manualMoves = input.manualMoves ?? [];
 
     const progressByDate = new Map<string, DailyProgress>();
     for (const p of dailyProgress) progressByDate.set(p.date, p);
@@ -109,11 +124,41 @@ export function replan(input: ReplanInput): ReplanResult {
 
     futureDays.sort((a, b) => a.date.localeCompare(b.date));
 
-    // --- 2. debt をグリーディに未来日へ詰め込む ---------------------------------------
-    // タスク完了状態 (各 future day の現在割当量)
+    // 各 future day の現在割当量
     const assigned = new Map<string, number>();
     for (const d of futureDays) assigned.set(d.date, d.planned);
 
+    // --- 1.5. manualMoves を先に適用 -------------------------------------------
+    let manualMovesApplied = 0;
+    const futureDateSet = new Set(futureDays.map((d) => d.date));
+    for (const mv of manualMoves) {
+        const fromValid = futureDateSet.has(mv.fromDate);
+        const toValid = futureDateSet.has(mv.toDate);
+        if (!fromValid || !toValid || mv.fromDate === mv.toDate) {
+            const fromQty = assigned.get(mv.fromDate) ?? 0;
+            if (fromQty > 0) {
+                overflowed.push({
+                    fromDate: mv.fromDate,
+                    questionCount: fromQty,
+                    reason: 'manual_move_invalid',
+                });
+            }
+            continue;
+        }
+        const qty = assigned.get(mv.fromDate) ?? 0;
+        if (qty <= 0) continue;
+        assigned.set(mv.fromDate, 0);
+        assigned.set(mv.toDate, (assigned.get(mv.toDate) ?? 0) + qty);
+        moved.push({
+            fromDate: mv.fromDate,
+            toDate: mv.toDate,
+            questionCount: qty,
+            reason: 'manual_move',
+        });
+        manualMovesApplied += 1;
+    }
+
+    // --- 2. debt をグリーディに未来日へ詰め込む ---------------------------------------
     let remaining = totalDebt;
     for (const debt of pastDebts) {
         let toRedistribute = debt.debt;
@@ -176,9 +221,10 @@ export function replan(input: ReplanInput): ReplanResult {
             overflowed,
             totalDebtQuestions: totalDebt,
             redistributedQuestions: totalDebt - remaining,
+            manualMovesApplied,
         },
         warnings,
         generatedAt: now,
-        algorithmVersion: '1.0',
+        algorithmVersion: manualMoves.length > 0 ? '1.5' : '1.0',
     };
 }

--- a/apps/web/lib/study-plan/editorState.ts
+++ b/apps/web/lib/study-plan/editorState.ts
@@ -1,0 +1,47 @@
+/**
+ * StudyPlan 編集 UI Phase 2 (#211): タスク単位 D&D 移動。
+ *
+ * Phase 1 (#189) の `EditState` (休 / 集中 / 通常) に加え、
+ * v1.5 では「ある日のタスク全量を別の日に移動」する `moves` を持つ。
+ *
+ * data shape:
+ *   - modes: Record<date, EditMode>          // 休/集中トグル
+ *   - moves: Record<fromDate, toDate>        // D&D / 移動ボタン
+ *
+ * 同じ fromDate に対する複数指示は最後勝ち。toDate は重複可（複数日が同じ日に集まる）。
+ */
+
+import type { EditMode, EditState } from '@/lib/study-plan/planEditActions';
+
+export interface EditorState {
+    modes: EditState;
+    moves: Record<string, string>;
+}
+
+export const EMPTY_EDITOR_STATE: EditorState = { modes: {}, moves: {} };
+
+export function setMode(state: EditorState, date: string, mode: EditMode): EditorState {
+    const modes = { ...state.modes };
+    if (mode === 'normal') delete modes[date];
+    else modes[date] = mode;
+    return { ...state, modes };
+}
+
+export function setMove(state: EditorState, fromDate: string, toDate: string): EditorState {
+    if (fromDate === toDate) return clearMove(state, fromDate);
+    return { ...state, moves: { ...state.moves, [fromDate]: toDate } };
+}
+
+export function clearMove(state: EditorState, fromDate: string): EditorState {
+    const moves = { ...state.moves };
+    delete moves[fromDate];
+    return { ...state, moves };
+}
+
+export function hasAnyEdit(state: EditorState): boolean {
+    return Object.keys(state.modes).length > 0 || Object.keys(state.moves).length > 0;
+}
+
+export function manualMovesFromState(state: EditorState): { fromDate: string; toDate: string }[] {
+    return Object.entries(state.moves).map(([fromDate, toDate]) => ({ fromDate, toDate }));
+}


### PR DESCRIPTION
Closes #211

## 概要
学習計画編集UIで「タスクを別の日に動かす」操作を D&D + a11y フォールバックの両系統で実装し、`replan()` を v1.5 に拡張して `manualMoves` を扱えるようにします。

## 変更内容

### サーバ
- `lib/plan/replan.ts` を **v1.5** に拡張
  - 入力に `manualMoves: { fromDate, toDate }[]` を追加
  - 過去 debt 再配分の **前に** 手動移動を適用 (= ユーザ意図を最優先)
  - 不正な移動 (過去日 / 同一日 / 計画外日付) は `manual_move_invalid` として `overflowed` に記録
  - `manualMoves` 指定時のみ `algorithmVersion: '1.5'`、未指定時は `'1.0'` (後方互換)
  - `diff.manualMovesApplied` 件数を返却
- `app/api/study-plan/replan/route.ts` で `manualMoves` を受付

### クライアント (PlanEditor)
- HTML5 D&D で別日へ移動 (デスクトップ)
- 各セルに「移動」ボタン → 日付選択ダイアログ (キーボード/スクリーンリーダ専用フロー)
- 移動予定の視覚化 (→ MM-DD 表示) + 取消ボタン
- `EditorState` に `modes` (休/集中) と `moves` (D&D/移動) を統合し、**Undo/Redo の対象**に
- 既存の Esc クローズ・aria-label を踏襲

## 設計メモ
- **タスクid を新設しない簡略化**: 現モデルは「1 日 1 タスク」のため `date` を実質的な taskId として扱う。これにより既存 `DailyTask` 型の破壊変更を回避
- **manualMoves は "問題数の転送"**: from の `questionCount` を to へ加算し、from を 0 にする (元々 `replan` が日単位で扱う仕組みと整合)
- **手動移動 → 過去 debt の順**: 手動移動を先に確定させてから debt を残った余地に詰める。debt が手動移動を上書きしない

## DoD 達成状況
- ✅ タスクをドラッグして別日に移動できる
- ✅ 移動結果の diff プレビュー → 「適用」で永続化 (#212 でサーバへも保存)
- ✅ キーボード / スクリーンリーダのみでも移動操作が完結 (移動ボタン + role="dialog" + select)
- ⚠️ E2E テストは本 PR では未追加 (Playwright 設定が現状リポジトリに無いため、ユニットテストで代替)

## テスト
- 新規 12 件 (replan v1.5: 6 / editorState: 6)
- 既存テスト含む全 **569 件 / 48 ファイル green**
- `npm run build` 成功
- `npx tsc --noEmit` clean

## 動作確認手順
1. `/dashboard?action=replan` を開く
2. カレンダーのセルをドラッグして別日へドロップ → セル右下に「→ MM-DD」表示
3. 「移動」ボタン (右上) → ダイアログから移動先選択 (キーボードのみ可)
4. 「変更をプレビュー」→ 「移動 [手動]」が diff に出る
5. 「適用」→ 計画に反映 + サーバ永続化 (#212)

## 関連
- 親: #189
- 依存: #188 (v1.0 → v1.5 拡張)
- 連動: #212 (永続化)