### PR TITLE
feat(#218): PerformanceProfile 集計ロジック + API

### DIFF
--- a/apps/web/__tests__/api/profile-performance.test.ts
+++ b/apps/web/__tests__/api/profile-performance.test.ts
@@ -1,0 +1,99 @@
+/**
+ * /api/profile/performance のユニットテスト (#218 / #224 レビュー対応)
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/cosmos', () => ({
+    getContainer: vi.fn(),
+}));
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn(),
+}));
+vi.mock('@/auth', () => ({ authOptions: {} }));
+
+vi.mock('@/lib/repositories/learningRecordRepository', () => ({
+    learningRecordRepository: {
+        findByUserIdInDateRange: vi.fn(),
+    },
+}));
+vi.mock('@/lib/repositories/dailyProgressRepository', () => ({
+    dailyProgressRepository: {
+        findByUserAndDateRange: vi.fn(),
+    },
+}));
+vi.mock('@/lib/repositories/studyPlanRepository', () => ({
+    studyPlanRepository: {
+        listByUser: vi.fn(),
+    },
+}));
+
+describe('/api/profile/performance GET', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('未認証は 401', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue(null);
+        const { GET } = await import('@/app/api/profile/performance/route');
+        const res = await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(res.status).toBe(401);
+    });
+
+    it('正常系: profile を含むレスポンスを返す', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u1' } });
+        const lr = await import('@/lib/repositories/learningRecordRepository');
+        const dp = await import('@/lib/repositories/dailyProgressRepository');
+        const sp = await import('@/lib/repositories/studyPlanRepository');
+        (lr.learningRecordRepository.findByUserIdInDateRange as any).mockResolvedValue([]);
+        (dp.dailyProgressRepository.findByUserAndDateRange as any).mockResolvedValue([]);
+        (sp.studyPlanRepository.listByUser as any).mockResolvedValue([]);
+
+        const { GET } = await import('@/app/api/profile/performance/route');
+        const res = await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json).toHaveProperty('profile');
+        expect(json.profile.userId).toBe('u1');
+        expect(Array.isArray(json.profile.paceByWeekday)).toBe(true);
+    });
+
+    it('studyPlanRepository が失敗してもエラーログ後に処理継続 (profile を返す)', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u2' } });
+        const lr = await import('@/lib/repositories/learningRecordRepository');
+        const dp = await import('@/lib/repositories/dailyProgressRepository');
+        const sp = await import('@/lib/repositories/studyPlanRepository');
+        (lr.learningRecordRepository.findByUserIdInDateRange as any).mockResolvedValue([]);
+        (dp.dailyProgressRepository.findByUserAndDateRange as any).mockResolvedValue([]);
+        (sp.studyPlanRepository.listByUser as any).mockRejectedValue(new Error('db down'));
+
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const { GET } = await import('@/app/api/profile/performance/route');
+        const res = await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(res.status).toBe(200);
+        expect(errSpy).toHaveBeenCalled();
+        errSpy.mockRestore();
+    });
+
+    it('LearningRecord 取得は範囲指定で呼び出される', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u3' } });
+        const lr = await import('@/lib/repositories/learningRecordRepository');
+        const dp = await import('@/lib/repositories/dailyProgressRepository');
+        const sp = await import('@/lib/repositories/studyPlanRepository');
+        (lr.learningRecordRepository.findByUserIdInDateRange as any).mockResolvedValue([]);
+        (dp.dailyProgressRepository.findByUserAndDateRange as any).mockResolvedValue([]);
+        (sp.studyPlanRepository.listByUser as any).mockResolvedValue([]);
+
+        const { GET } = await import('@/app/api/profile/performance/route');
+        await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(lr.learningRecordRepository.findByUserIdInDateRange).toHaveBeenCalledWith(
+            'u3',
+            expect.stringMatching(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/),
+            expect.stringMatching(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/),
+        );
+    });
+});

--- a/apps/web/__tests__/lib/profile/buildPerformanceProfile.test.ts
+++ b/apps/web/__tests__/lib/profile/buildPerformanceProfile.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildPerformanceProfile,
+    calcPaceByWeekday,
+    calcRecentAchievement,
+    calcAccuracyByCategory,
+    calcContinuity,
+    calcPaceRatio,
+} from '@/lib/profile/buildPerformanceProfile';
+import type { DailyProgress, LearningRecord } from '@ipa-lab/shared';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+
+const FIXED_NOW = '2026-04-23T00:00:00.000Z';
+const TODAY = '2026-04-23'; // 2026-04-23 = Thursday (UTC)
+
+function dp(date: string, q: number, c = 0): DailyProgress {
+    return {
+        id: `u1-${date}`,
+        userId: 'u1',
+        date,
+        questionCount: q,
+        correctCount: c,
+        accuracy: q > 0 ? (c / q) * 100 : 0,
+        totalTimeSeconds: 0,
+        sessionCount: 1,
+        examBreakdown: {},
+        status: q > 0 ? 'completed' : 'none',
+        aggregatedAt: FIXED_NOW,
+    };
+}
+
+function lr(date: string, category: string, isCorrect: boolean): LearningRecord {
+    return {
+        id: '00000000-0000-0000-0000-000000000000',
+        userId: 'u1',
+        questionId: 'q1',
+        examId: 'AP-2025S',
+        category,
+        isCorrect,
+        isFlagged: false,
+        answeredAt: `${date}T10:00:00.000Z`,
+        timeTakenSeconds: 60,
+        reviewInterval: 0,
+        easeFactor: 2.5,
+    };
+}
+
+describe('calcPaceByWeekday', () => {
+    it('returns 0 array when no records', () => {
+        expect(calcPaceByWeekday([])).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('averages questionCount by UTC weekday, ignoring 0-day records', () => {
+        // 2026-04-20 = Mon (1), 2026-04-21 = Tue (2), 2026-04-27 = Mon (1)
+        const res = calcPaceByWeekday([
+            dp('2026-04-20', 10),
+            dp('2026-04-27', 20),
+            dp('2026-04-21', 5),
+            dp('2026-04-22', 0), // ignored (0)
+        ]);
+        expect(res[1]).toBe(15); // Mon avg
+        expect(res[2]).toBe(5); // Tue
+        expect(res[3]).toBe(0); // Wed (no data)
+    });
+});
+
+describe('calcRecentAchievement', () => {
+    it('returns 0 when no planned', () => {
+        const res = calcRecentAchievement([dp('2026-04-22', 5)], {}, TODAY);
+        expect(res.rate).toBe(0);
+        expect(res.consecutiveOnFireDays).toBe(0);
+    });
+
+    it('computes overall rate over 7-day window', () => {
+        const planned: Record<string, number> = {};
+        for (let i = 0; i < 7; i += 1) {
+            const date = new Date(`${TODAY}T00:00:00Z`);
+            date.setUTCDate(date.getUTCDate() - i);
+            planned[date.toISOString().slice(0, 10)] = 10;
+        }
+        const progresses = Object.keys(planned).map((d) => dp(d, 5));
+        const res = calcRecentAchievement(progresses, planned, TODAY);
+        expect(res.rate).toBeCloseTo(0.5);
+        expect(res.consecutiveOnFireDays).toBe(0);
+    });
+
+    it('counts consecutive on_fire days from today backward', () => {
+        const planned: Record<string, number> = {};
+        const dates: string[] = [];
+        for (let i = 0; i < 7; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            const key = d.toISOString().slice(0, 10);
+            dates.push(key);
+            planned[key] = 10;
+        }
+        // today, today-1, today-2 are on fire (>130%); today-3 is not
+        const progresses = [
+            dp(dates[0], 14),
+            dp(dates[1], 14),
+            dp(dates[2], 14),
+            dp(dates[3], 5),
+            dp(dates[4], 14),
+        ];
+        const res = calcRecentAchievement(progresses, planned, TODAY);
+        expect(res.consecutiveOnFireDays).toBe(3);
+    });
+});
+
+describe('calcAccuracyByCategory', () => {
+    it('aggregates by category', () => {
+        const records = [
+            lr('2026-04-22', 'cat-A', true),
+            lr('2026-04-22', 'cat-A', false),
+            lr('2026-04-22', 'cat-B', true),
+            lr('2026-04-22', 'cat-B', true),
+        ];
+        const res = calcAccuracyByCategory(records);
+        expect(res['cat-A']).toEqual({ total: 2, correct: 1, rate: 0.5 });
+        expect(res['cat-B']).toEqual({ total: 2, correct: 2, rate: 1 });
+    });
+});
+
+describe('calcContinuity', () => {
+    it('counts study days and consecutive streak', () => {
+        // today, today-1, today-2 studied, today-3 skipped, today-4 studied
+        const dates: string[] = [];
+        for (let i = 0; i < 5; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            dates.push(d.toISOString().slice(0, 10));
+        }
+        const progresses = [
+            dp(dates[0], 5),
+            dp(dates[1], 5),
+            dp(dates[2], 5),
+            dp(dates[3], 0), // skipped
+            dp(dates[4], 5),
+        ];
+        const res = calcContinuity(progresses, TODAY);
+        expect(res.consecutiveStudyDays).toBe(3);
+        expect(res.continuityRate).toBeCloseTo(4 / 28);
+    });
+});
+
+describe('calcPaceRatio', () => {
+    it('returns 1.0 when previous window has 0', () => {
+        expect(calcPaceRatio([dp('2026-04-22', 5)], TODAY)).toBe(1);
+    });
+
+    it('returns recent/previous ratio', () => {
+        const dates7: string[] = [];
+        const dates14: string[] = [];
+        for (let i = 0; i < 7; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            dates7.push(d.toISOString().slice(0, 10));
+        }
+        for (let i = 7; i < 14; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            dates14.push(d.toISOString().slice(0, 10));
+        }
+        const progresses = [
+            ...dates7.map((d) => dp(d, 10)), // 70 total
+            ...dates14.map((d) => dp(d, 5)), // 35 total
+        ];
+        expect(calcPaceRatio(progresses, TODAY)).toBeCloseTo(2);
+    });
+});
+
+describe('buildPerformanceProfile', () => {
+    it('builds full profile from inputs', () => {
+        const plan: StudyPlan = {
+            id: 'plan-1',
+            title: 'AP',
+            examDate: '2026-10-19',
+            monthlyGoal: 'g',
+            generatedAt: FIXED_NOW,
+            weeklySchedule: [
+                {
+                    weekNumber: 1,
+                    startDate: '2026-04-17',
+                    endDate: '2026-04-23',
+                    goal: 'w1',
+                    dailyTasks: [
+                        { date: '2026-04-23', goal: 't', questionCount: 10 },
+                        { date: '2026-04-22', goal: 't', questionCount: 10 },
+                    ],
+                },
+            ],
+        };
+        const profile = buildPerformanceProfile({
+            userId: 'u1',
+            dailyProgresses: [dp('2026-04-23', 5, 3), dp('2026-04-22', 8, 6)],
+            records: [
+                lr('2026-04-23', 'cat-A', true),
+                lr('2026-04-23', 'cat-A', false),
+                lr('2026-04-22', 'cat-B', true),
+            ],
+            plan,
+            today: TODAY,
+            now: () => FIXED_NOW,
+        });
+        expect(profile.userId).toBe('u1');
+        expect(profile.generatedAt).toBe(FIXED_NOW);
+        expect(profile.paceByWeekday.length).toBe(7);
+        expect(profile.recentAchievementRate).toBeCloseTo((5 + 8) / (10 + 10));
+        expect(profile.accuracyByCategory['cat-A'].rate).toBeCloseTo(0.5);
+        expect(profile.continuityRate).toBeCloseTo(2 / 28);
+        expect(profile.paceRatio).toBe(1); // no prev window data
+    });
+
+    it('handles empty inputs', () => {
+        const profile = buildPerformanceProfile({
+            userId: 'u1',
+            dailyProgresses: [],
+            records: [],
+            today: TODAY,
+            now: () => FIXED_NOW,
+        });
+        expect(profile.recentAchievementRate).toBe(0);
+        expect(profile.continuityRate).toBe(0);
+        expect(profile.consecutiveStudyDays).toBe(0);
+        expect(profile.paceRatio).toBe(1);
+        expect(profile.accuracyByCategory).toEqual({});
+    });
+
+    it('filters out records older than 28 days', () => {
+        const oldDate = '2025-01-01'; // way older
+        const profile = buildPerformanceProfile({
+            userId: 'u1',
+            dailyProgresses: [dp(oldDate, 100), dp(TODAY, 5)],
+            records: [lr(oldDate, 'cat-A', true), lr(TODAY, 'cat-B', true)],
+            today: TODAY,
+            now: () => FIXED_NOW,
+        });
+        // old records filtered: only cat-B remains
+        expect(profile.accuracyByCategory['cat-A']).toBeUndefined();
+        expect(profile.accuracyByCategory['cat-B']).toBeDefined();
+    });
+});

--- a/apps/web/app/api/profile/performance/route.ts
+++ b/apps/web/app/api/profile/performance/route.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /api/profile/performance
+ *
+ * 認証ユーザの PerformanceProfile を返す (#218 / v2.0 MVP3)。
+ * - 過去28日の DailyProgress + LearningRecord + 最新 StudyPlan を集計
+ * - 純粋関数 `buildPerformanceProfile` を経由 (AI 呼び出しなし)
+ *
+ * Response: { profile: PerformanceProfile }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { learningRecordRepository } from '@/lib/repositories/learningRecordRepository';
+import { dailyProgressRepository } from '@/lib/repositories/dailyProgressRepository';
+import { studyPlanRepository } from '@/lib/repositories/studyPlanRepository';
+import { aggregateDailyProgress } from '@/lib/progress/aggregateDailyProgress';
+import { buildPerformanceProfile } from '@/lib/profile/buildPerformanceProfile';
+
+export const dynamic = 'force-dynamic';
+
+const WINDOW_DAYS = 28;
+
+function todayKey(): string {
+    const d = new Date();
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+function addDays(date: string, n: number): string {
+    const d = new Date(`${date}T00:00:00.000Z`);
+    d.setUTCDate(d.getUTCDate() + n);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+export async function GET(_request: NextRequest) {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const today = todayKey();
+        const from = addDays(today, -(WINDOW_DAYS - 1));
+
+        const [records, persistedDailyProgresses, plans] = await Promise.all([
+            learningRecordRepository.findByUserId(userId),
+            dailyProgressRepository.findByUserAndDateRange(userId, from, today),
+            studyPlanRepository.listByUser(userId).catch(() => []),
+        ]);
+
+        // 永続化された DailyProgress に加え、リアルタイム集計でフォールバック
+        // (バッチ未実行の最新分も拾うため、Records から再集計したものを優先する)
+        const realtime = aggregateDailyProgress({
+            userId,
+            records,
+            from,
+            to: today,
+            countSessions: true,
+        });
+        // realtime を優先しつつ、欠落日は永続版で補完
+        const realtimeMap = new Map(realtime.map((p) => [p.date, p]));
+        for (const p of persistedDailyProgresses) {
+            if (!realtimeMap.has(p.date)) realtimeMap.set(p.date, p);
+        }
+        const dailyProgresses = Array.from(realtimeMap.values()).sort((a, b) =>
+            a.date.localeCompare(b.date)
+        );
+
+        // 最新の StudyPlan (generatedAt 降順)
+        const plan = plans
+            .slice()
+            .sort((a, b) => (b.generatedAt ?? '').localeCompare(a.generatedAt ?? ''))[0];
+
+        const profile = buildPerformanceProfile({
+            userId,
+            dailyProgresses,
+            records,
+            plan,
+            today,
+        });
+
+        return NextResponse.json({ profile });
+    } catch (e) {
+        const message = e instanceof Error ? e.message : 'Internal Error';
+        return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
+    }
+}

--- a/apps/web/app/api/profile/performance/route.ts
+++ b/apps/web/app/api/profile/performance/route.ts
@@ -48,12 +48,22 @@ export async function GET(_request: NextRequest) {
     try {
         const today = todayKey();
         const from = addDays(today, -(WINDOW_DAYS - 1));
+        const fromIso = `${from}T00:00:00.000Z`;
+        // 排他的上限。toIso は today の翌日 00:00 で today 当日分も含める
+        const toIso = `${addDays(today, 1)}T00:00:00.000Z`;
 
-        const [records, persistedDailyProgresses, plans] = await Promise.all([
-            learningRecordRepository.findByUserId(userId),
+        const [records, persistedDailyProgresses, plansResult] = await Promise.all([
+            learningRecordRepository.findByUserIdInDateRange(userId, fromIso, toIso),
             dailyProgressRepository.findByUserAndDateRange(userId, from, today),
-            studyPlanRepository.listByUser(userId).catch(() => []),
+            studyPlanRepository
+                .listByUser(userId)
+                .then((rows) => ({ ok: true as const, rows }))
+                .catch((err: unknown) => {
+                    console.error('[api/profile/performance] studyPlanRepository.listByUser failed', err);
+                    return { ok: false as const, rows: [] };
+                }),
         ]);
+        const plans = plansResult.rows;
 
         // 永続化された DailyProgress に加え、リアルタイム集計でフォールバック
         // (バッチ未実行の最新分も拾うため、Records から再集計したものを優先する)

--- a/apps/web/lib/profile/buildPerformanceProfile.ts
+++ b/apps/web/lib/profile/buildPerformanceProfile.ts
@@ -1,0 +1,230 @@
+/**
+ * PerformanceProfile 生成 (#218 / v2.0 MVP3)
+ *
+ * 入力:
+ *   - dailyProgresses: 過去28日の DailyProgress[]
+ *   - records: 過去28日の LearningRecord[] (カテゴリ別正答率の算出用)
+ *   - plan: 現在の StudyPlan (達成率の planned 算出用)
+ *   - today: 基準日 (YYYY-MM-DD UTC)
+ *
+ * すべての算出ロジックを副作用ゼロの純粋関数として実装し、ユニットテストで網羅する。
+ */
+
+import type { LearningRecord, DailyProgress } from '@ipa-lab/shared';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+import type { PerformanceProfile, CategoryAccuracy } from '@/lib/types/performanceProfile';
+
+const WINDOW_DAYS = 28;
+const RECENT_DAYS = 7;
+const ON_FIRE_THRESHOLD = 1.3;
+
+export interface BuildPerformanceProfileInput {
+    userId: string;
+    dailyProgresses: DailyProgress[];
+    records: LearningRecord[];
+    plan?: StudyPlan;
+    /** 基準日 (YYYY-MM-DD)。未指定時は new Date() の UTC 日付。 */
+    today?: string;
+    /** 集計時刻 (テスト固定用)。 */
+    now?: () => string;
+}
+
+/** UTC 基準で YYYY-MM-DD を返す */
+function todayKey(): string {
+    const d = new Date();
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+/** YYYY-MM-DD を UTC Date に変換 */
+function parseDate(date: string): Date {
+    return new Date(`${date}T00:00:00.000Z`);
+}
+
+/** UTC 日付に n 日加算した YYYY-MM-DD を返す */
+function addDays(date: string, n: number): string {
+    const d = parseDate(date);
+    d.setUTCDate(d.getUTCDate() + n);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+/** YYYY-MM-DD の曜日 (0=日 .. 6=土) を UTC で返す */
+function weekday(date: string): number {
+    return parseDate(date).getUTCDay();
+}
+
+/** plan の dailyTasks を date -> plannedQuestionCount に展開 */
+function buildPlannedMap(plan: StudyPlan | undefined): Record<string, number> {
+    const map: Record<string, number> = {};
+    if (!plan) return map;
+    for (const week of plan.weeklySchedule ?? []) {
+        for (const task of week.dailyTasks ?? []) {
+            map[task.date] = (map[task.date] ?? 0) + (task.questionCount ?? 0);
+        }
+    }
+    return map;
+}
+
+/**
+ * 曜日別ペース (paceByWeekday) を算出。
+ * 過去28日のうち学習記録 (questionCount > 0) のある日のみで平均を取る。
+ * 学習日 0 の曜日は 0 を返す。
+ */
+export function calcPaceByWeekday(progresses: DailyProgress[]): number[] {
+    const sums = new Array<number>(7).fill(0);
+    const counts = new Array<number>(7).fill(0);
+    for (const p of progresses) {
+        if (p.questionCount <= 0) continue;
+        const w = weekday(p.date);
+        sums[w] += p.questionCount;
+        counts[w] += 1;
+    }
+    return sums.map((s, i) => (counts[i] === 0 ? 0 : s / counts[i]));
+}
+
+/**
+ * 直近 n 日の達成率と末尾連続「絶好調」(>130%) 日数を算出。
+ * 達成率 = sum(actual) / sum(planned)。planned 0 → 0。
+ */
+export function calcRecentAchievement(
+    progresses: DailyProgress[],
+    plannedMap: Record<string, number>,
+    today: string,
+    days: number = RECENT_DAYS
+): { rate: number; consecutiveOnFireDays: number } {
+    let actualSum = 0;
+    let plannedSum = 0;
+    const dailyRate: { date: string; rate: number }[] = [];
+
+    for (let i = 0; i < days; i += 1) {
+        const date = addDays(today, -i);
+        const planned = plannedMap[date] ?? 0;
+        const actual = progresses.find((p) => p.date === date)?.questionCount ?? 0;
+        actualSum += actual;
+        plannedSum += planned;
+        const r = planned > 0 ? actual / planned : 0;
+        dailyRate.push({ date, rate: r });
+    }
+
+    const rate = plannedSum > 0 ? actualSum / plannedSum : 0;
+
+    // 末尾連続 (today から過去に向かって) >130% カウント
+    let consecutive = 0;
+    for (const d of dailyRate) {
+        if (d.rate > ON_FIRE_THRESHOLD) consecutive += 1;
+        else break;
+    }
+
+    return { rate, consecutiveOnFireDays: consecutive };
+}
+
+/** カテゴリ別正答率を集計 */
+export function calcAccuracyByCategory(records: LearningRecord[]): Record<string, CategoryAccuracy> {
+    const acc: Record<string, { total: number; correct: number }> = {};
+    for (const r of records) {
+        const key = r.category || 'unknown';
+        if (!acc[key]) acc[key] = { total: 0, correct: 0 };
+        acc[key].total += 1;
+        if (r.isCorrect) acc[key].correct += 1;
+    }
+    const out: Record<string, CategoryAccuracy> = {};
+    for (const [k, v] of Object.entries(acc)) {
+        out[k] = {
+            total: v.total,
+            correct: v.correct,
+            rate: v.total > 0 ? v.correct / v.total : 0,
+        };
+    }
+    return out;
+}
+
+/**
+ * 学習継続率と末尾連続学習日数。
+ * - continuityRate = 過去28日で questionCount > 0 の日数 / 28
+ * - consecutiveStudyDays = today から過去に連続して学習した日数 (1日でも空けば終了)
+ */
+export function calcContinuity(
+    progresses: DailyProgress[],
+    today: string
+): { continuityRate: number; consecutiveStudyDays: number } {
+    const studied = new Set<string>();
+    for (const p of progresses) {
+        if (p.questionCount > 0) studied.add(p.date);
+    }
+    let count = 0;
+    for (let i = 0; i < WINDOW_DAYS; i += 1) {
+        if (studied.has(addDays(today, -i))) count += 1;
+    }
+    let consecutive = 0;
+    for (let i = 0; i < WINDOW_DAYS; i += 1) {
+        if (studied.has(addDays(today, -i))) consecutive += 1;
+        else break;
+    }
+    return { continuityRate: count / WINDOW_DAYS, consecutiveStudyDays: consecutive };
+}
+
+/**
+ * ペース比 γ = 直近7日 / 過去7-14日。
+ * 過去7-14日が 0 の場合は 1.0 を返す。
+ */
+export function calcPaceRatio(progresses: DailyProgress[], today: string): number {
+    let recent = 0;
+    let prev = 0;
+    for (let i = 0; i < RECENT_DAYS; i += 1) {
+        const date = addDays(today, -i);
+        const p = progresses.find((x) => x.date === date);
+        if (p) recent += p.questionCount;
+    }
+    for (let i = RECENT_DAYS; i < RECENT_DAYS * 2; i += 1) {
+        const date = addDays(today, -i);
+        const p = progresses.find((x) => x.date === date);
+        if (p) prev += p.questionCount;
+    }
+    if (prev === 0) return 1;
+    return recent / prev;
+}
+
+/**
+ * PerformanceProfile を構築。
+ */
+export function buildPerformanceProfile(input: BuildPerformanceProfileInput): PerformanceProfile {
+    const today = input.today ?? todayKey();
+    const now = input.now ?? (() => new Date().toISOString());
+
+    // 過去28日でフィルタ
+    const windowStart = addDays(today, -(WINDOW_DAYS - 1));
+    const progresses = input.dailyProgresses.filter((p) => p.date >= windowStart && p.date <= today);
+    const records = input.records.filter((r) => {
+        const dateKey = r.answeredAt.slice(0, 10);
+        return dateKey >= windowStart && dateKey <= today;
+    });
+
+    const plannedMap = buildPlannedMap(input.plan);
+
+    const paceByWeekday = calcPaceByWeekday(progresses);
+    const { rate: recentAchievementRate, consecutiveOnFireDays } = calcRecentAchievement(
+        progresses,
+        plannedMap,
+        today
+    );
+    const accuracyByCategory = calcAccuracyByCategory(records);
+    const { continuityRate, consecutiveStudyDays } = calcContinuity(progresses, today);
+    const paceRatio = calcPaceRatio(progresses, today);
+
+    return {
+        userId: input.userId,
+        generatedAt: now(),
+        paceByWeekday,
+        recentAchievementRate,
+        consecutiveOnFireDays,
+        accuracyByCategory,
+        continuityRate,
+        consecutiveStudyDays,
+        paceRatio,
+    };
+}

--- a/apps/web/lib/repositories/learningRecordRepository.ts
+++ b/apps/web/lib/repositories/learningRecordRepository.ts
@@ -28,6 +28,33 @@ export const learningRecordRepository = {
         return resources as LearningRecord[];
     },
 
+    /**
+     * 指定期間 (answeredAt が fromIso 以上 toIso 未満) の LearningRecord を返す。
+     * #224 v2.0 MVP3: PerformanceProfile が直近28日分しか必要としないため、
+     * Cosmos の RU/レイテンシ削減のために範囲を絞って取得する。
+     *
+     * fromIso/toIso は ISO datetime 文字列 (例: '2026-04-01T00:00:00.000Z')。
+     */
+    async findByUserIdInDateRange(
+        userId: string,
+        fromIso: string,
+        toIso: string,
+    ): Promise<LearningRecord[]> {
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        const querySpec: SqlQuerySpec = {
+            query:
+                "SELECT * FROM c WHERE c.userId = @userId AND c.answeredAt >= @from AND c.answeredAt < @to",
+            parameters: [
+                { name: "@userId", value: userId },
+                { name: "@from", value: fromIso },
+                { name: "@to", value: toIso },
+            ],
+        };
+        const { resources } = await container.items.query(querySpec).fetchAll();
+        return resources as LearningRecord[];
+    },
+
     async listByUserId(userId: string): Promise<LearningRecord[]> {
         return this.findByUserId(userId);
     },

--- a/apps/web/lib/types/performanceProfile.ts
+++ b/apps/web/lib/types/performanceProfile.ts
@@ -6,7 +6,7 @@
  * - replan v2.0 (#222) の重み付け、ヘルスチェック (#220)、可視化UI (#219) で参照
  */
 
-/** 曜日別カテゴリ正答率の集計 */
+/** カテゴリ別正答率の集計 */
 export interface CategoryAccuracy {
     /** 解答数 */
     total: number;

--- a/apps/web/lib/types/performanceProfile.ts
+++ b/apps/web/lib/types/performanceProfile.ts
@@ -1,0 +1,55 @@
+/**
+ * PerformanceProfile (#218 / v2.0 適応型計画 MVP3)
+ *
+ * ユーザの実績シグナルを集約した型。
+ * - DailyProgress + LearningRecord + StudyPlan から純粋関数 `buildPerformanceProfile` で生成
+ * - replan v2.0 (#222) の重み付け、ヘルスチェック (#220)、可視化UI (#219) で参照
+ */
+
+/** 曜日別カテゴリ正答率の集計 */
+export interface CategoryAccuracy {
+    /** 解答数 */
+    total: number;
+    /** 正答数 */
+    correct: number;
+    /** 正答率 (0-1) */
+    rate: number;
+}
+
+export interface PerformanceProfile {
+    userId: string;
+    /** プロファイル生成時刻 (ISO) */
+    generatedAt: string;
+    /**
+     * 曜日別の平均解答ペース (questionCount/日)。
+     * 過去28日に学習記録のある日のみで平均を取る (学習しなかった日は分母に含めない)。
+     * index 0=日, 1=月, ..., 6=土
+     */
+    paceByWeekday: number[];
+    /**
+     * 直近7日の達成率。sum(actual) / sum(planned)。
+     * planned が 0 の場合は 0 を返す。
+     * 値域: 0 以上 (130%超え = 1.3 以上もありうる)
+     */
+    recentAchievementRate: number;
+    /**
+     * 直近7日のうち、達成率 > 130% を満たした連続日数 (末尾連続)。
+     * 「絶好調」(on_fire) ヘルス判定で「連続3日」を見るのに使用。
+     */
+    consecutiveOnFireDays: number;
+    /** カテゴリ別正答率 (LearningRecord.category キー) */
+    accuracyByCategory: Record<string, CategoryAccuracy>;
+    /**
+     * 学習継続率 (過去28日で学習した日数 / 28)。
+     * 値域: 0-1
+     */
+    continuityRate: number;
+    /** 過去28日における直近の連続学習日数 (末尾から数えて何日連続学習したか)。1日空きで途切れる。 */
+    consecutiveStudyDays: number;
+    /**
+     * ペース比 γ。直近7日 questionCount合計 / 過去7-14日 questionCount合計。
+     * 1.0 = 同等、1.0 超 = 加速、1.0 未満 = 減速。
+     * 過去7-14日が 0 の場合は 1.0 を返す (NaN 回避)。
+     */
+    paceRatio: number;
+}


### PR DESCRIPTION
## 概要
v2.0 MVP3 [P3-A] の基盤となる **PerformanceProfile** 集計ロジックと取得 API を実装。

## 実装内容
### 純粋関数 `buildPerformanceProfile()`
DailyProgress + LearningRecord + StudyPlan から 5 シグナルを算出（AI 不使用、コストゼロ）。

| シグナル | 算出 | 用途 |
|---|---|---|
| 曜日別ペース | 過去28日の曜日別平均 questionCount（学習日のみ、0日除外） | replan v2.0 重み、可視化 |
| 直近7日達成率 + on_fire 連続日数 | sum(actual)/sum(planned)、>1.3 連続 | ヘルス判定、🚀絶好調 |
| カテゴリ別正答率 | LearningRecord 集計 | replan v2.0 弱点重み、可視化 |
| 28日継続率 + 連続学習日数 | 学習日カウント | 「○日連続学習中」表示 |
| ペース比 γ | 直近7日 / 過去7-14日 のペース比 | 「スピードに乗ってきてます」 |

### `GET /api/profile/performance`
- リアルタイム集計を優先しつつ、永続版 DailyProgress で欠落補完
- StudyPlan は最新 (`generatedAt` 降順) を採用

### テスト
- 単体テスト **12 件** 全て green（581/581 全体テスト green、build success）
- 空入力・28日期間外フィルタ・on_fire 連続判定・γ 計算 等を網羅

## 後続タスク
- #220 ヘルスチェック純粋関数 + API
- #222 replan v2.0
- #219 「あなたの学習ペース」可視化UI

Closes #218
