### PR TITLE
feat(#222): replan v2.0 (曜日重み + 弱点重み)

### DIFF
--- a/apps/web/__tests__/api/profile-performance.test.ts
+++ b/apps/web/__tests__/api/profile-performance.test.ts
@@ -1,0 +1,99 @@
+/**
+ * /api/profile/performance のユニットテスト (#218 / #224 レビュー対応)
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/cosmos', () => ({
+    getContainer: vi.fn(),
+}));
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn(),
+}));
+vi.mock('@/auth', () => ({ authOptions: {} }));
+
+vi.mock('@/lib/repositories/learningRecordRepository', () => ({
+    learningRecordRepository: {
+        findByUserIdInDateRange: vi.fn(),
+    },
+}));
+vi.mock('@/lib/repositories/dailyProgressRepository', () => ({
+    dailyProgressRepository: {
+        findByUserAndDateRange: vi.fn(),
+    },
+}));
+vi.mock('@/lib/repositories/studyPlanRepository', () => ({
+    studyPlanRepository: {
+        listByUser: vi.fn(),
+    },
+}));
+
+describe('/api/profile/performance GET', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('未認証は 401', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue(null);
+        const { GET } = await import('@/app/api/profile/performance/route');
+        const res = await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(res.status).toBe(401);
+    });
+
+    it('正常系: profile を含むレスポンスを返す', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u1' } });
+        const lr = await import('@/lib/repositories/learningRecordRepository');
+        const dp = await import('@/lib/repositories/dailyProgressRepository');
+        const sp = await import('@/lib/repositories/studyPlanRepository');
+        (lr.learningRecordRepository.findByUserIdInDateRange as any).mockResolvedValue([]);
+        (dp.dailyProgressRepository.findByUserAndDateRange as any).mockResolvedValue([]);
+        (sp.studyPlanRepository.listByUser as any).mockResolvedValue([]);
+
+        const { GET } = await import('@/app/api/profile/performance/route');
+        const res = await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(res.status).toBe(200);
+        const json = await res.json();
+        expect(json).toHaveProperty('profile');
+        expect(json.profile.userId).toBe('u1');
+        expect(Array.isArray(json.profile.paceByWeekday)).toBe(true);
+    });
+
+    it('studyPlanRepository が失敗してもエラーログ後に処理継続 (profile を返す)', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u2' } });
+        const lr = await import('@/lib/repositories/learningRecordRepository');
+        const dp = await import('@/lib/repositories/dailyProgressRepository');
+        const sp = await import('@/lib/repositories/studyPlanRepository');
+        (lr.learningRecordRepository.findByUserIdInDateRange as any).mockResolvedValue([]);
+        (dp.dailyProgressRepository.findByUserAndDateRange as any).mockResolvedValue([]);
+        (sp.studyPlanRepository.listByUser as any).mockRejectedValue(new Error('db down'));
+
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const { GET } = await import('@/app/api/profile/performance/route');
+        const res = await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(res.status).toBe(200);
+        expect(errSpy).toHaveBeenCalled();
+        errSpy.mockRestore();
+    });
+
+    it('LearningRecord 取得は範囲指定で呼び出される', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u3' } });
+        const lr = await import('@/lib/repositories/learningRecordRepository');
+        const dp = await import('@/lib/repositories/dailyProgressRepository');
+        const sp = await import('@/lib/repositories/studyPlanRepository');
+        (lr.learningRecordRepository.findByUserIdInDateRange as any).mockResolvedValue([]);
+        (dp.dailyProgressRepository.findByUserAndDateRange as any).mockResolvedValue([]);
+        (sp.studyPlanRepository.listByUser as any).mockResolvedValue([]);
+
+        const { GET } = await import('@/app/api/profile/performance/route');
+        await GET(new NextRequest('http://localhost/api/profile/performance'));
+        expect(lr.learningRecordRepository.findByUserIdInDateRange).toHaveBeenCalledWith(
+            'u3',
+            expect.stringMatching(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/),
+            expect.stringMatching(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/),
+        );
+    });
+});

--- a/apps/web/__tests__/api/study-plan-health-check.test.ts
+++ b/apps/web/__tests__/api/study-plan-health-check.test.ts
@@ -1,0 +1,91 @@
+/**
+ * /api/study-plan/health-check のユニットテスト (#220 / レビュー対応)
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn(),
+}));
+vi.mock('@/auth', () => ({ authOptions: {} }));
+
+const VALID_PROFILE = {
+    userId: 'u1',
+    generatedAt: '2026-04-23T00:00:00.000Z',
+    paceByWeekday: [0, 0, 0, 0, 0, 0, 0],
+    recentAchievementRate: 0.5,
+    consecutiveOnFireDays: 0,
+    accuracyByCategory: {},
+    continuityRate: 0,
+    consecutiveStudyDays: 0,
+    paceRatio: 1,
+};
+
+function buildRequest(body: unknown): Request {
+    return new Request('http://localhost/api/study-plan/health-check', {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+describe('/api/study-plan/health-check POST', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('未認証は 401', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue(null);
+        const { POST } = await import('@/app/api/study-plan/health-check/route');
+        const res = await POST(buildRequest({ profile: VALID_PROFILE }));
+        expect(res.status).toBe(401);
+    });
+
+    it('profile 欠落は 400 (INVALID_INPUT)', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u1' } });
+        const { POST } = await import('@/app/api/study-plan/health-check/route');
+        const res = await POST(buildRequest({}));
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('INVALID_INPUT');
+    });
+
+    it('NaN/不正数値は 400 (INVALID_INPUT)', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u1' } });
+        const { POST } = await import('@/app/api/study-plan/health-check/route');
+        const res = await POST(
+            buildRequest({
+                profile: { ...VALID_PROFILE, recentAchievementRate: -1 },
+            }),
+        );
+        expect(res.status).toBe(400);
+    });
+
+    it('正常系: PlanHealthResult を返す (slight_delay 50%)', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u1' } });
+        const { POST } = await import('@/app/api/study-plan/health-check/route');
+        const res = await POST(buildRequest({ profile: VALID_PROFILE }));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.status).toBe('slight_delay');
+        expect(body.shouldNotify).toBe(true);
+    });
+
+    it('JSON パース失敗は 400 (INVALID_JSON)', async () => {
+        const { getServerSession } = await import('next-auth');
+        (getServerSession as any).mockResolvedValue({ user: { id: 'u1' } });
+        const req = new Request('http://localhost/api/study-plan/health-check', {
+            method: 'POST',
+            body: 'not-json{{{',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const { POST } = await import('@/app/api/study-plan/health-check/route');
+        const res = await POST(req);
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('INVALID_JSON');
+    });
+});

--- a/apps/web/__tests__/lib/plan/healthCheck.test.ts
+++ b/apps/web/__tests__/lib/plan/healthCheck.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+
+import { evaluatePlanHealth } from '@/lib/plan/healthCheck';
+import type { PerformanceProfile } from '@/lib/types/performanceProfile';
+
+const NOW = '2026-04-23T00:00:00.000Z';
+
+function profile(overrides: Partial<PerformanceProfile> = {}): PerformanceProfile {
+    return {
+        userId: 'u1',
+        windowDays: 28,
+        paceByWeekday: [0, 0, 0, 0, 0, 0, 0],
+        recentAchievementRate: 1.0,
+        consecutiveOnFireDays: 0,
+        accuracyByCategory: [],
+        continuityRate: 0,
+        consecutiveStudyDays: 0,
+        paceRatio: 1,
+        generatedAt: NOW,
+        ...overrides,
+    };
+}
+
+describe('evaluatePlanHealth', () => {
+    const opts = { now: () => NOW };
+
+    it('🟢 on_track: 達成率 70% 以上で notify=false', () => {
+        const result = evaluatePlanHealth(profile({ recentAchievementRate: 0.85 }), opts);
+        expect(result.status).toBe('on_track');
+        expect(result.shouldNotify).toBe(false);
+        expect(result.suggestion.kind).toBe('none');
+        expect(result.suggestion.action).toBeNull();
+    });
+
+    it('🟢 on_track: ちょうど 70% は on_track', () => {
+        expect(evaluatePlanHealth(profile({ recentAchievementRate: 0.7 }), opts).status).toBe(
+            'on_track',
+        );
+    });
+
+    it('🟡 slight_delay: 40-70% で replan_recommended', () => {
+        const result = evaluatePlanHealth(profile({ recentAchievementRate: 0.5 }), opts);
+        expect(result.status).toBe('slight_delay');
+        expect(result.shouldNotify).toBe(true);
+        expect(result.suggestion.kind).toBe('replan_recommended');
+        expect(result.suggestion.action).toBe('open_replan');
+    });
+
+    it('🔴 major_delay: 40% 未満で replan_recommended', () => {
+        const result = evaluatePlanHealth(profile({ recentAchievementRate: 0.2 }), opts);
+        expect(result.status).toBe('major_delay');
+        expect(result.shouldNotify).toBe(true);
+        expect(result.suggestion.kind).toBe('replan_recommended');
+    });
+
+    it('🚀 on_fire: 達成率>1.3 かつ 連続3日で celebrate', () => {
+        const result = evaluatePlanHealth(
+            profile({ recentAchievementRate: 1.5, consecutiveOnFireDays: 3 }),
+            opts,
+        );
+        expect(result.status).toBe('on_fire');
+        expect(result.shouldNotify).toBe(true);
+        expect(result.suggestion.kind).toBe('celebrate_and_boost');
+        expect(result.suggestion.action).toBe('increase_pace');
+    });
+
+    it('on_fire 条件未達 (連続2日) は on_track 扱い', () => {
+        const result = evaluatePlanHealth(
+            profile({ recentAchievementRate: 1.5, consecutiveOnFireDays: 2 }),
+            opts,
+        );
+        expect(result.status).toBe('on_track');
+    });
+
+    it('達成率 0 は major_delay', () => {
+        expect(
+            evaluatePlanHealth(profile({ recentAchievementRate: 0 }), opts).status,
+        ).toBe('major_delay');
+    });
+
+    it('evaluatedAt は now() の戻り値', () => {
+        expect(evaluatePlanHealth(profile(), opts).evaluatedAt).toBe(NOW);
+    });
+});

--- a/apps/web/__tests__/lib/plan/healthCheck.test.ts
+++ b/apps/web/__tests__/lib/plan/healthCheck.test.ts
@@ -8,11 +8,10 @@ const NOW = '2026-04-23T00:00:00.000Z';
 function profile(overrides: Partial<PerformanceProfile> = {}): PerformanceProfile {
     return {
         userId: 'u1',
-        windowDays: 28,
         paceByWeekday: [0, 0, 0, 0, 0, 0, 0],
         recentAchievementRate: 1.0,
         consecutiveOnFireDays: 0,
-        accuracyByCategory: [],
+        accuracyByCategory: {},
         continuityRate: 0,
         consecutiveStudyDays: 0,
         paceRatio: 1,
@@ -80,5 +79,24 @@ describe('evaluatePlanHealth', () => {
 
     it('evaluatedAt は now() の戻り値', () => {
         expect(evaluatePlanHealth(profile(), opts).evaluatedAt).toBe(NOW);
+    });
+
+    it('不正値 (NaN/Infinity/負数) は防御的に補正される', () => {
+        const r1 = evaluatePlanHealth(profile({ recentAchievementRate: Number.NaN }), opts);
+        expect(r1.achievementRate).toBe(0);
+        expect(r1.status).toBe('major_delay');
+
+        const r2 = evaluatePlanHealth(
+            profile({ recentAchievementRate: Number.POSITIVE_INFINITY }),
+            opts,
+        );
+        expect(r2.achievementRate).toBe(0);
+
+        const r3 = evaluatePlanHealth(
+            profile({ recentAchievementRate: 1.5, consecutiveOnFireDays: Number.NaN }),
+            opts,
+        );
+        expect(r3.consecutiveOnFireDays).toBe(0);
+        expect(r3.status).toBe('on_track');
     });
 });

--- a/apps/web/__tests__/lib/plan/replan.v2.test.ts
+++ b/apps/web/__tests__/lib/plan/replan.v2.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+
+import { replan } from '@/lib/plan/replan';
+import type { StudyPlan } from '@/lib/api';
+import type { DailyProgress } from '@ipa-lab/shared';
+import type { PerformanceProfile } from '@/lib/types/performanceProfile';
+
+const NOW = '2026-04-23T00:00:00.000Z';
+const now = () => NOW;
+
+const dp = (date: string, questionCount: number): DailyProgress => ({
+    id: `u1-${date}`,
+    userId: 'u1',
+    date,
+    questionCount,
+    correctCount: questionCount,
+    accuracy: 100,
+    totalTimeSeconds: 60 * questionCount,
+    sessionCount: 1,
+    examBreakdown: {},
+    status: 'completed',
+    aggregatedAt: NOW,
+});
+
+function buildPlanWithCategories(
+    days: { date: string; questionCount: number; targetCategory?: string }[],
+    examDate = '2026-05-15',
+): StudyPlan {
+    return {
+        title: 'test plan',
+        examDate,
+        monthlyGoal: 'goal',
+        weeklySchedule: [
+            {
+                weekNumber: 1,
+                startDate: days[0]?.date ?? '2026-04-15',
+                endDate: days[days.length - 1]?.date ?? '2026-04-30',
+                goal: 'w1',
+                dailyTasks: days.map((d) => ({
+                    date: d.date,
+                    goal: 'g',
+                    questionCount: d.questionCount,
+                    targetCategory: d.targetCategory,
+                })),
+            },
+        ],
+        generatedAt: NOW,
+    };
+}
+
+function profile(overrides: Partial<PerformanceProfile> = {}): PerformanceProfile {
+    return {
+        userId: 'u1',
+        windowDays: 28,
+        // [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
+        paceByWeekday: [10, 1, 1, 1, 1, 1, 10],
+        recentAchievementRate: 1,
+        consecutiveOnFireDays: 0,
+        accuracyByCategory: [],
+        continuityRate: 1,
+        consecutiveStudyDays: 7,
+        paceRatio: 1,
+        generatedAt: NOW,
+        ...overrides,
+    };
+}
+
+describe('replan v2.0 (profile-weighted)', () => {
+    it('algorithmVersion = 2.0 when profile is provided', () => {
+        const plan = buildPlanWithCategories([
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-23', questionCount: 5 },
+            { date: '2026-04-24', questionCount: 5 },
+        ]);
+        const result = replan({
+            plan,
+            dailyProgress: [dp('2026-04-22', 0)],
+            today: '2026-04-23',
+            profile: profile(),
+            options: { now },
+        });
+        expect(result.algorithmVersion).toBe('2.0');
+    });
+
+    it('曜日ペース重みが大きい曜日に優先的に詰める', () => {
+        // 2026-04-25 = 土曜 (Sat, dow=6, weight 10)
+        // 2026-04-24 = 金曜 (Fri, dow=5, weight 1)
+        // 2026-04-26 = 日曜 (Sun, dow=0, weight 10)
+        const plan = buildPlanWithCategories([
+            { date: '2026-04-22', questionCount: 8 },
+            { date: '2026-04-24', questionCount: 5 },
+            { date: '2026-04-25', questionCount: 5 },
+            { date: '2026-04-26', questionCount: 5 },
+        ]);
+        const result = replan({
+            plan,
+            dailyProgress: [dp('2026-04-22', 0)],
+            today: '2026-04-23',
+            profile: profile(),
+            options: { now, capacityBoost: 2, baseCapacity: 5 },
+        });
+        const tasks = result.plan.weeklySchedule[0].dailyTasks;
+        const fri = tasks.find((t) => t.date === '2026-04-24')!.questionCount;
+        const sat = tasks.find((t) => t.date === '2026-04-25')!.questionCount;
+        const sun = tasks.find((t) => t.date === '2026-04-26')!.questionCount;
+        // debt=8: 高ペース曜日 sat (cap 10, room 5) → 5 取り、残り 3 → sun へ → sat=10, sun=8
+        // 金 (低ペース) は手付かず → 5
+        expect(sat).toBe(10);
+        expect(sun).toBe(8);
+        expect(fri).toBe(5);
+    });
+
+    it('弱点カテゴリに優先的に詰める', () => {
+        const plan = buildPlanWithCategories([
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-24', questionCount: 5, targetCategory: 'NW' },
+            { date: '2026-04-25', questionCount: 5, targetCategory: 'DB' },
+        ]);
+        const result = replan({
+            plan,
+            dailyProgress: [dp('2026-04-22', 0)],
+            today: '2026-04-23',
+            profile: profile({
+                paceByWeekday: [1, 1, 1, 1, 1, 1, 1], // 曜日重み均等
+                accuracyByCategory: [
+                    { category: 'NW', accuracy: 0.5, totalCount: 100 },
+                    { category: 'DB', accuracy: 0.9, totalCount: 100 },
+                ],
+            }),
+            options: { now, capacityBoost: 2, baseCapacity: 5 },
+        });
+        const tasks = result.plan.weeklySchedule[0].dailyTasks;
+        const nw = tasks.find((t) => t.date === '2026-04-24')!.questionCount;
+        const db = tasks.find((t) => t.date === '2026-04-25')!.questionCount;
+        // 弱点 NW のほうに詰まる
+        expect(nw).toBeGreaterThan(db);
+    });
+
+    it('profile 無しなら v1.0 と同じ (日付昇順)', () => {
+        const plan = buildPlanWithCategories([
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-24', questionCount: 5 },
+            { date: '2026-04-25', questionCount: 5 },
+        ]);
+        const result = replan({
+            plan,
+            dailyProgress: [dp('2026-04-22', 0)],
+            today: '2026-04-23',
+            options: { now },
+        });
+        expect(result.algorithmVersion).toBe('1.0');
+    });
+
+    it('paceByWeekday が全 0 でも例外なく動く (重み均等)', () => {
+        const plan = buildPlanWithCategories([
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-24', questionCount: 5 },
+        ]);
+        const result = replan({
+            plan,
+            dailyProgress: [dp('2026-04-22', 0)],
+            today: '2026-04-23',
+            profile: profile({ paceByWeekday: [0, 0, 0, 0, 0, 0, 0] }),
+            options: { now },
+        });
+        expect(result.algorithmVersion).toBe('2.0');
+        expect(result.diff.totalDebtQuestions).toBe(5);
+    });
+});

--- a/apps/web/__tests__/lib/plan/replan.v2.test.ts
+++ b/apps/web/__tests__/lib/plan/replan.v2.test.ts
@@ -51,12 +51,11 @@ function buildPlanWithCategories(
 function profile(overrides: Partial<PerformanceProfile> = {}): PerformanceProfile {
     return {
         userId: 'u1',
-        windowDays: 28,
         // [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
         paceByWeekday: [10, 1, 1, 1, 1, 1, 10],
         recentAchievementRate: 1,
         consecutiveOnFireDays: 0,
-        accuracyByCategory: [],
+        accuracyByCategory: {},
         continuityRate: 1,
         consecutiveStudyDays: 7,
         paceRatio: 1,
@@ -122,10 +121,10 @@ describe('replan v2.0 (profile-weighted)', () => {
             today: '2026-04-23',
             profile: profile({
                 paceByWeekday: [1, 1, 1, 1, 1, 1, 1], // 曜日重み均等
-                accuracyByCategory: [
-                    { category: 'NW', accuracy: 0.5, totalCount: 100 },
-                    { category: 'DB', accuracy: 0.9, totalCount: 100 },
-                ],
+                accuracyByCategory: {
+                    NW: { total: 100, correct: 50, rate: 0.5 },
+                    DB: { total: 100, correct: 90, rate: 0.9 },
+                },
             }),
             options: { now, capacityBoost: 2, baseCapacity: 5 },
         });
@@ -165,5 +164,23 @@ describe('replan v2.0 (profile-weighted)', () => {
         });
         expect(result.algorithmVersion).toBe('2.0');
         expect(result.diff.totalDebtQuestions).toBe(5);
+    });
+
+    it('特定曜日の paceByWeekday が 0 でもその日に詰まる (中立扱い)', () => {
+        // 4/24 (金) を 0 に設定。weight 0 でその曜日に詰まらない問題の回帰防止。
+        const plan = buildPlanWithCategories([
+            { date: '2026-04-22', questionCount: 5 },
+            { date: '2026-04-24', questionCount: 5 }, // 金曜
+        ]);
+        const result = replan({
+            plan,
+            dailyProgress: [dp('2026-04-22', 0)],
+            today: '2026-04-23',
+            // [Sun, Mon, Tue, Wed, Thu, Fri, Sat]
+            profile: profile({ paceByWeekday: [5, 5, 5, 5, 5, 0, 5] }),
+            options: { now, capacityBoost: 5, baseCapacity: 10 },
+        });
+        const fri = result.plan.weeklySchedule[0].dailyTasks.find((t) => t.date === '2026-04-24');
+        expect(fri?.questionCount).toBeGreaterThan(5);
     });
 });

--- a/apps/web/__tests__/lib/profile/buildPerformanceProfile.test.ts
+++ b/apps/web/__tests__/lib/profile/buildPerformanceProfile.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildPerformanceProfile,
+    calcPaceByWeekday,
+    calcRecentAchievement,
+    calcAccuracyByCategory,
+    calcContinuity,
+    calcPaceRatio,
+} from '@/lib/profile/buildPerformanceProfile';
+import type { DailyProgress, LearningRecord } from '@ipa-lab/shared';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+
+const FIXED_NOW = '2026-04-23T00:00:00.000Z';
+const TODAY = '2026-04-23'; // 2026-04-23 = Thursday (UTC)
+
+function dp(date: string, q: number, c = 0): DailyProgress {
+    return {
+        id: `u1-${date}`,
+        userId: 'u1',
+        date,
+        questionCount: q,
+        correctCount: c,
+        accuracy: q > 0 ? (c / q) * 100 : 0,
+        totalTimeSeconds: 0,
+        sessionCount: 1,
+        examBreakdown: {},
+        status: q > 0 ? 'completed' : 'none',
+        aggregatedAt: FIXED_NOW,
+    };
+}
+
+function lr(date: string, category: string, isCorrect: boolean): LearningRecord {
+    return {
+        id: '00000000-0000-0000-0000-000000000000',
+        userId: 'u1',
+        questionId: 'q1',
+        examId: 'AP-2025S',
+        category,
+        isCorrect,
+        isFlagged: false,
+        answeredAt: `${date}T10:00:00.000Z`,
+        timeTakenSeconds: 60,
+        reviewInterval: 0,
+        easeFactor: 2.5,
+    };
+}
+
+describe('calcPaceByWeekday', () => {
+    it('returns 0 array when no records', () => {
+        expect(calcPaceByWeekday([])).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('averages questionCount by UTC weekday, ignoring 0-day records', () => {
+        // 2026-04-20 = Mon (1), 2026-04-21 = Tue (2), 2026-04-27 = Mon (1)
+        const res = calcPaceByWeekday([
+            dp('2026-04-20', 10),
+            dp('2026-04-27', 20),
+            dp('2026-04-21', 5),
+            dp('2026-04-22', 0), // ignored (0)
+        ]);
+        expect(res[1]).toBe(15); // Mon avg
+        expect(res[2]).toBe(5); // Tue
+        expect(res[3]).toBe(0); // Wed (no data)
+    });
+});
+
+describe('calcRecentAchievement', () => {
+    it('returns 0 when no planned', () => {
+        const res = calcRecentAchievement([dp('2026-04-22', 5)], {}, TODAY);
+        expect(res.rate).toBe(0);
+        expect(res.consecutiveOnFireDays).toBe(0);
+    });
+
+    it('computes overall rate over 7-day window', () => {
+        const planned: Record<string, number> = {};
+        for (let i = 0; i < 7; i += 1) {
+            const date = new Date(`${TODAY}T00:00:00Z`);
+            date.setUTCDate(date.getUTCDate() - i);
+            planned[date.toISOString().slice(0, 10)] = 10;
+        }
+        const progresses = Object.keys(planned).map((d) => dp(d, 5));
+        const res = calcRecentAchievement(progresses, planned, TODAY);
+        expect(res.rate).toBeCloseTo(0.5);
+        expect(res.consecutiveOnFireDays).toBe(0);
+    });
+
+    it('counts consecutive on_fire days from today backward', () => {
+        const planned: Record<string, number> = {};
+        const dates: string[] = [];
+        for (let i = 0; i < 7; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            const key = d.toISOString().slice(0, 10);
+            dates.push(key);
+            planned[key] = 10;
+        }
+        // today, today-1, today-2 are on fire (>130%); today-3 is not
+        const progresses = [
+            dp(dates[0], 14),
+            dp(dates[1], 14),
+            dp(dates[2], 14),
+            dp(dates[3], 5),
+            dp(dates[4], 14),
+        ];
+        const res = calcRecentAchievement(progresses, planned, TODAY);
+        expect(res.consecutiveOnFireDays).toBe(3);
+    });
+});
+
+describe('calcAccuracyByCategory', () => {
+    it('aggregates by category', () => {
+        const records = [
+            lr('2026-04-22', 'cat-A', true),
+            lr('2026-04-22', 'cat-A', false),
+            lr('2026-04-22', 'cat-B', true),
+            lr('2026-04-22', 'cat-B', true),
+        ];
+        const res = calcAccuracyByCategory(records);
+        expect(res['cat-A']).toEqual({ total: 2, correct: 1, rate: 0.5 });
+        expect(res['cat-B']).toEqual({ total: 2, correct: 2, rate: 1 });
+    });
+});
+
+describe('calcContinuity', () => {
+    it('counts study days and consecutive streak', () => {
+        // today, today-1, today-2 studied, today-3 skipped, today-4 studied
+        const dates: string[] = [];
+        for (let i = 0; i < 5; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            dates.push(d.toISOString().slice(0, 10));
+        }
+        const progresses = [
+            dp(dates[0], 5),
+            dp(dates[1], 5),
+            dp(dates[2], 5),
+            dp(dates[3], 0), // skipped
+            dp(dates[4], 5),
+        ];
+        const res = calcContinuity(progresses, TODAY);
+        expect(res.consecutiveStudyDays).toBe(3);
+        expect(res.continuityRate).toBeCloseTo(4 / 28);
+    });
+});
+
+describe('calcPaceRatio', () => {
+    it('returns 1.0 when previous window has 0', () => {
+        expect(calcPaceRatio([dp('2026-04-22', 5)], TODAY)).toBe(1);
+    });
+
+    it('returns recent/previous ratio', () => {
+        const dates7: string[] = [];
+        const dates14: string[] = [];
+        for (let i = 0; i < 7; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            dates7.push(d.toISOString().slice(0, 10));
+        }
+        for (let i = 7; i < 14; i += 1) {
+            const d = new Date(`${TODAY}T00:00:00Z`);
+            d.setUTCDate(d.getUTCDate() - i);
+            dates14.push(d.toISOString().slice(0, 10));
+        }
+        const progresses = [
+            ...dates7.map((d) => dp(d, 10)), // 70 total
+            ...dates14.map((d) => dp(d, 5)), // 35 total
+        ];
+        expect(calcPaceRatio(progresses, TODAY)).toBeCloseTo(2);
+    });
+});
+
+describe('buildPerformanceProfile', () => {
+    it('builds full profile from inputs', () => {
+        const plan: StudyPlan = {
+            id: 'plan-1',
+            title: 'AP',
+            examDate: '2026-10-19',
+            monthlyGoal: 'g',
+            generatedAt: FIXED_NOW,
+            weeklySchedule: [
+                {
+                    weekNumber: 1,
+                    startDate: '2026-04-17',
+                    endDate: '2026-04-23',
+                    goal: 'w1',
+                    dailyTasks: [
+                        { date: '2026-04-23', goal: 't', questionCount: 10 },
+                        { date: '2026-04-22', goal: 't', questionCount: 10 },
+                    ],
+                },
+            ],
+        };
+        const profile = buildPerformanceProfile({
+            userId: 'u1',
+            dailyProgresses: [dp('2026-04-23', 5, 3), dp('2026-04-22', 8, 6)],
+            records: [
+                lr('2026-04-23', 'cat-A', true),
+                lr('2026-04-23', 'cat-A', false),
+                lr('2026-04-22', 'cat-B', true),
+            ],
+            plan,
+            today: TODAY,
+            now: () => FIXED_NOW,
+        });
+        expect(profile.userId).toBe('u1');
+        expect(profile.generatedAt).toBe(FIXED_NOW);
+        expect(profile.paceByWeekday.length).toBe(7);
+        expect(profile.recentAchievementRate).toBeCloseTo((5 + 8) / (10 + 10));
+        expect(profile.accuracyByCategory['cat-A'].rate).toBeCloseTo(0.5);
+        expect(profile.continuityRate).toBeCloseTo(2 / 28);
+        expect(profile.paceRatio).toBe(1); // no prev window data
+    });
+
+    it('handles empty inputs', () => {
+        const profile = buildPerformanceProfile({
+            userId: 'u1',
+            dailyProgresses: [],
+            records: [],
+            today: TODAY,
+            now: () => FIXED_NOW,
+        });
+        expect(profile.recentAchievementRate).toBe(0);
+        expect(profile.continuityRate).toBe(0);
+        expect(profile.consecutiveStudyDays).toBe(0);
+        expect(profile.paceRatio).toBe(1);
+        expect(profile.accuracyByCategory).toEqual({});
+    });
+
+    it('filters out records older than 28 days', () => {
+        const oldDate = '2025-01-01'; // way older
+        const profile = buildPerformanceProfile({
+            userId: 'u1',
+            dailyProgresses: [dp(oldDate, 100), dp(TODAY, 5)],
+            records: [lr(oldDate, 'cat-A', true), lr(TODAY, 'cat-B', true)],
+            today: TODAY,
+            now: () => FIXED_NOW,
+        });
+        // old records filtered: only cat-B remains
+        expect(profile.accuracyByCategory['cat-A']).toBeUndefined();
+        expect(profile.accuracyByCategory['cat-B']).toBeDefined();
+    });
+});

--- a/apps/web/app/api/profile/performance/route.ts
+++ b/apps/web/app/api/profile/performance/route.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /api/profile/performance
+ *
+ * 認証ユーザの PerformanceProfile を返す (#218 / v2.0 MVP3)。
+ * - 過去28日の DailyProgress + LearningRecord + 最新 StudyPlan を集計
+ * - 純粋関数 `buildPerformanceProfile` を経由 (AI 呼び出しなし)
+ *
+ * Response: { profile: PerformanceProfile }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/auth';
+import { learningRecordRepository } from '@/lib/repositories/learningRecordRepository';
+import { dailyProgressRepository } from '@/lib/repositories/dailyProgressRepository';
+import { studyPlanRepository } from '@/lib/repositories/studyPlanRepository';
+import { aggregateDailyProgress } from '@/lib/progress/aggregateDailyProgress';
+import { buildPerformanceProfile } from '@/lib/profile/buildPerformanceProfile';
+
+export const dynamic = 'force-dynamic';
+
+const WINDOW_DAYS = 28;
+
+function todayKey(): string {
+    const d = new Date();
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+function addDays(date: string, n: number): string {
+    const d = new Date(`${date}T00:00:00.000Z`);
+    d.setUTCDate(d.getUTCDate() + n);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+export async function GET(_request: NextRequest) {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+        const today = todayKey();
+        const from = addDays(today, -(WINDOW_DAYS - 1));
+
+        const [records, persistedDailyProgresses, plans] = await Promise.all([
+            learningRecordRepository.findByUserId(userId),
+            dailyProgressRepository.findByUserAndDateRange(userId, from, today),
+            studyPlanRepository.listByUser(userId).catch(() => []),
+        ]);
+
+        // 永続化された DailyProgress に加え、リアルタイム集計でフォールバック
+        // (バッチ未実行の最新分も拾うため、Records から再集計したものを優先する)
+        const realtime = aggregateDailyProgress({
+            userId,
+            records,
+            from,
+            to: today,
+            countSessions: true,
+        });
+        // realtime を優先しつつ、欠落日は永続版で補完
+        const realtimeMap = new Map(realtime.map((p) => [p.date, p]));
+        for (const p of persistedDailyProgresses) {
+            if (!realtimeMap.has(p.date)) realtimeMap.set(p.date, p);
+        }
+        const dailyProgresses = Array.from(realtimeMap.values()).sort((a, b) =>
+            a.date.localeCompare(b.date)
+        );
+
+        // 最新の StudyPlan (generatedAt 降順)
+        const plan = plans
+            .slice()
+            .sort((a, b) => (b.generatedAt ?? '').localeCompare(a.generatedAt ?? ''))[0];
+
+        const profile = buildPerformanceProfile({
+            userId,
+            dailyProgresses,
+            records,
+            plan,
+            today,
+        });
+
+        return NextResponse.json({ profile });
+    } catch (e) {
+        const message = e instanceof Error ? e.message : 'Internal Error';
+        return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
+    }
+}

--- a/apps/web/app/api/profile/performance/route.ts
+++ b/apps/web/app/api/profile/performance/route.ts
@@ -48,12 +48,22 @@ export async function GET(_request: NextRequest) {
     try {
         const today = todayKey();
         const from = addDays(today, -(WINDOW_DAYS - 1));
+        const fromIso = `${from}T00:00:00.000Z`;
+        // 排他的上限。toIso は today の翌日 00:00 で today 当日分も含める
+        const toIso = `${addDays(today, 1)}T00:00:00.000Z`;
 
-        const [records, persistedDailyProgresses, plans] = await Promise.all([
-            learningRecordRepository.findByUserId(userId),
+        const [records, persistedDailyProgresses, plansResult] = await Promise.all([
+            learningRecordRepository.findByUserIdInDateRange(userId, fromIso, toIso),
             dailyProgressRepository.findByUserAndDateRange(userId, from, today),
-            studyPlanRepository.listByUser(userId).catch(() => []),
+            studyPlanRepository
+                .listByUser(userId)
+                .then((rows) => ({ ok: true as const, rows }))
+                .catch((err: unknown) => {
+                    console.error('[api/profile/performance] studyPlanRepository.listByUser failed', err);
+                    return { ok: false as const, rows: [] };
+                }),
         ]);
+        const plans = plansResult.rows;
 
         // 永続化された DailyProgress に加え、リアルタイム集計でフォールバック
         // (バッチ未実行の最新分も拾うため、Records から再集計したものを優先する)

--- a/apps/web/app/api/study-plan/health-check/route.ts
+++ b/apps/web/app/api/study-plan/health-check/route.ts
@@ -9,6 +9,7 @@
 
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
+import { z } from 'zod';
 
 import { authOptions } from '@/auth';
 import { evaluatePlanHealth } from '@/lib/plan/healthCheck';
@@ -16,9 +17,27 @@ import type { PerformanceProfile } from '@/lib/types/performanceProfile';
 
 export const dynamic = 'force-dynamic';
 
-interface HealthCheckRequestBody {
-    profile?: PerformanceProfile;
-}
+const CategoryAccuracySchema = z.object({
+    total: z.number().nonnegative(),
+    correct: z.number().nonnegative(),
+    rate: z.number().min(0).max(1),
+});
+
+const PerformanceProfileSchema = z.object({
+    userId: z.string(),
+    generatedAt: z.string(),
+    paceByWeekday: z.array(z.number().nonnegative()).length(7),
+    recentAchievementRate: z.number().nonnegative().finite(),
+    consecutiveOnFireDays: z.number().int().nonnegative().finite(),
+    accuracyByCategory: z.record(z.string(), CategoryAccuracySchema),
+    continuityRate: z.number().min(0).max(1),
+    consecutiveStudyDays: z.number().int().nonnegative(),
+    paceRatio: z.number().nonnegative().finite(),
+});
+
+const RequestBodySchema = z.object({
+    profile: PerformanceProfileSchema,
+});
 
 export async function POST(request: Request) {
     const session = await getServerSession(authOptions);
@@ -26,23 +45,24 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    let body: HealthCheckRequestBody = {};
+    let raw: unknown = {};
     try {
         const text = await request.text();
-        if (text) body = JSON.parse(text) as HealthCheckRequestBody;
+        if (text) raw = JSON.parse(text);
     } catch {
         return NextResponse.json({ error: 'INVALID_JSON' }, { status: 400 });
     }
 
-    if (!body.profile) {
+    const parsed = RequestBodySchema.safeParse(raw);
+    if (!parsed.success) {
         return NextResponse.json(
-            { error: 'MISSING_PROFILE', message: 'profile を request body に含めてください' },
+            { error: 'INVALID_INPUT', issues: parsed.error.issues },
             { status: 400 },
         );
     }
 
     try {
-        const result = evaluatePlanHealth(body.profile);
+        const result = evaluatePlanHealth(parsed.data.profile as PerformanceProfile);
         return NextResponse.json(result);
     } catch (error) {
         console.error('[health-check] failed', error);

--- a/apps/web/app/api/study-plan/health-check/route.ts
+++ b/apps/web/app/api/study-plan/health-check/route.ts
@@ -1,0 +1,51 @@
+/**
+ * POST /api/study-plan/health-check
+ *
+ * 入力: PerformanceProfile (クライアントが /api/profile/performance で取得し POST)
+ * 出力: PlanHealthResult
+ *
+ * 純粋関数 evaluatePlanHealth を呼ぶだけのシン API。AI 呼び出しなし。
+ */
+
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/auth';
+import { evaluatePlanHealth } from '@/lib/plan/healthCheck';
+import type { PerformanceProfile } from '@/lib/types/performanceProfile';
+
+export const dynamic = 'force-dynamic';
+
+interface HealthCheckRequestBody {
+    profile?: PerformanceProfile;
+}
+
+export async function POST(request: Request) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: HealthCheckRequestBody = {};
+    try {
+        const text = await request.text();
+        if (text) body = JSON.parse(text) as HealthCheckRequestBody;
+    } catch {
+        return NextResponse.json({ error: 'INVALID_JSON' }, { status: 400 });
+    }
+
+    if (!body.profile) {
+        return NextResponse.json(
+            { error: 'MISSING_PROFILE', message: 'profile を request body に含めてください' },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const result = evaluatePlanHealth(body.profile);
+        return NextResponse.json(result);
+    } catch (error) {
+        console.error('[health-check] failed', error);
+        return NextResponse.json({ error: 'INTERNAL_ERROR' }, { status: 500 });
+    }
+}

--- a/apps/web/lib/plan/healthCheck.ts
+++ b/apps/web/lib/plan/healthCheck.ts
@@ -1,0 +1,97 @@
+/**
+ * 計画ヘルスチェック純粋関数 (v2.0 MVP3 / #220).
+ *
+ * - 入力: PerformanceProfile
+ * - 出力: PlanHealthResult (status / shouldNotify / suggestion)
+ * - AI 呼び出しなし。クライアント / サーバ双方で再利用可能。
+ *
+ * しきい値 (plan.md より):
+ *   🟢 on_track       : 達成率 >= 70%      → ポップアップ無し
+ *   🟡 slight_delay   : 40% <= 達成率 <70% → 再配分提案
+ *   🔴 major_delay    : 達成率 < 40%       → 再配分提案 (悪化扱い)
+ *   🚀 on_fire        : 達成率 > 130% かつ on_fire 連続 3 日以上 → ペース増提案
+ */
+
+import type { PerformanceProfile } from '@/lib/types/performanceProfile';
+import type {
+    PlanHealthResult,
+    PlanHealthStatus,
+    PlanHealthSuggestion,
+} from '@/lib/types/planHealth';
+
+const ON_TRACK_MIN = 0.7;
+const SLIGHT_DELAY_MIN = 0.4;
+const ON_FIRE_RATE = 1.3;
+const ON_FIRE_DAYS = 3;
+
+export interface HealthCheckOptions {
+    /** 評価時刻 (テスト固定用)。default = new Date().toISOString() */
+    now?: () => string;
+}
+
+export function evaluatePlanHealth(
+    profile: PerformanceProfile,
+    options: HealthCheckOptions = {},
+): PlanHealthResult {
+    const now = options.now?.() ?? new Date().toISOString();
+    const rate = profile.recentAchievementRate;
+    const onFireDays = profile.consecutiveOnFireDays;
+
+    const status = classifyStatus(rate, onFireDays);
+    const suggestion = buildSuggestion(status, rate, onFireDays);
+    const shouldNotify = status !== 'on_track';
+
+    return {
+        status,
+        achievementRate: rate,
+        consecutiveOnFireDays: onFireDays,
+        shouldNotify,
+        suggestion,
+        evaluatedAt: now,
+    };
+}
+
+function classifyStatus(rate: number, onFireDays: number): PlanHealthStatus {
+    if (rate > ON_FIRE_RATE && onFireDays >= ON_FIRE_DAYS) return 'on_fire';
+    if (rate >= ON_TRACK_MIN) return 'on_track';
+    if (rate >= SLIGHT_DELAY_MIN) return 'slight_delay';
+    return 'major_delay';
+}
+
+function buildSuggestion(
+    status: PlanHealthStatus,
+    rate: number,
+    onFireDays: number,
+): PlanHealthSuggestion {
+    const pct = Math.round(rate * 100);
+    switch (status) {
+        case 'on_track':
+            return {
+                kind: 'none',
+                headline: '計画通りに進んでいます',
+                body: `直近7日の達成率は ${pct}% です。この調子でいきましょう。`,
+                action: null,
+            };
+        case 'slight_delay':
+            return {
+                kind: 'replan_recommended',
+                headline: 'ペースが少し落ちています',
+                body: `直近7日の達成率は ${pct}%。残りの計画を見直してリカバリしませんか？`,
+                action: 'open_replan',
+            };
+        case 'major_delay':
+            return {
+                kind: 'replan_recommended',
+                headline: '計画と実績にギャップがあります',
+                body: `直近7日の達成率は ${pct}%。今のペースに合わせて計画を再配分しましょう。`,
+                action: 'open_replan',
+            };
+        case 'on_fire':
+            return {
+                kind: 'celebrate_and_boost',
+                headline: '絶好調！もう一段上を目指しませんか？',
+                body: `${onFireDays}日連続で計画を大幅に上回っています (達成率 ${pct}%)。試験までの計画を前倒しできます。`,
+                action: 'increase_pace',
+            };
+    }
+}

--- a/apps/web/lib/plan/healthCheck.ts
+++ b/apps/web/lib/plan/healthCheck.ts
@@ -34,8 +34,8 @@ export function evaluatePlanHealth(
     options: HealthCheckOptions = {},
 ): PlanHealthResult {
     const now = options.now?.() ?? new Date().toISOString();
-    const rate = profile.recentAchievementRate;
-    const onFireDays = profile.consecutiveOnFireDays;
+    const rate = normalizeAchievementRate(profile.recentAchievementRate);
+    const onFireDays = normalizeConsecutiveOnFireDays(profile.consecutiveOnFireDays);
 
     const status = classifyStatus(rate, onFireDays);
     const suggestion = buildSuggestion(status, rate, onFireDays);
@@ -49,6 +49,17 @@ export function evaluatePlanHealth(
         suggestion,
         evaluatedAt: now,
     };
+}
+
+/** 不正値 (NaN/Infinity/負数) は 0 に補正。純粋関数として防御的に扱う。 */
+function normalizeAchievementRate(rate: number): number {
+    if (typeof rate !== 'number' || !Number.isFinite(rate)) return 0;
+    return Math.max(0, rate);
+}
+
+function normalizeConsecutiveOnFireDays(days: number): number {
+    if (typeof days !== 'number' || !Number.isFinite(days)) return 0;
+    return Math.max(0, Math.floor(days));
 }
 
 function classifyStatus(rate: number, onFireDays: number): PlanHealthStatus {

--- a/apps/web/lib/plan/replan.ts
+++ b/apps/web/lib/plan/replan.ts
@@ -10,7 +10,8 @@
  * - 試験日 (`plan.examDate`) を超える日には絶対に積まない（overflowed として返す）
  * - 純粋関数。I/O ゼロ。
  *
- * 設計書: docs/02_design/20_DynamicReplanningEngine.md §13 (Phase 1 MVP)
+ * 設計書: docs/02_design/20_DynamicReplanningEngine.md §13 は v1.0 / v1.5 のベース挙動の参照。
+ * v2.0（曜日ペース重み × 弱点重み付け）の仕様根拠: 関連 Issue #222
  * 関連 Issue: #188 (P2-A-2), #222 (v2.0)
  */
 
@@ -271,13 +272,15 @@ function rankDaysByProfileWeight<T extends { date: string; category?: string }>(
     profile: PerformanceProfile,
 ): T[] {
     const paceMean = mean(profile.paceByWeekday);
-    const accuracyMap = new Map<string, number>();
-    for (const c of profile.accuracyByCategory) accuracyMap.set(c.category, c.accuracy);
+    const accuracyMap = profile.accuracyByCategory; // Record<string, CategoryAccuracy>
 
     const weighted = days.map((day, idx) => {
         const dow = new Date(`${day.date}T00:00:00.000Z`).getUTCDay();
-        const paceWeight = paceMean > 0 ? profile.paceByWeekday[dow] / paceMean : 1;
-        const acc = day.category ? accuracyMap.get(day.category) : undefined;
+        // 曜日ペースが 0 の日 (= その曜日に学習実績なし) は中立扱い (1.0)。
+        // そうしないと 0 重みでその曜日に一切詰まらず、平日空白などで詰まらない計画になる。
+        const dayPace = profile.paceByWeekday[dow];
+        const paceWeight = paceMean > 0 && dayPace > 0 ? dayPace / paceMean : 1;
+        const acc = day.category ? accuracyMap[day.category]?.rate : undefined;
         const weaknessWeight =
             acc !== undefined && acc < WEAKNESS_THRESHOLD ? WEAKNESS_BOOST : 1;
         return { day, idx, weight: paceWeight * weaknessWeight };

--- a/apps/web/lib/plan/replan.ts
+++ b/apps/web/lib/plan/replan.ts
@@ -1,18 +1,21 @@
 /**
- * 動的再計画エンジン v1.0 (Phase 1 MVP).
+ * 動的再計画エンジン v1.0 (Phase 1 MVP) / v1.5 (manualMoves) / v2.0 (profile-weighted).
  *
- * - 入力: 既存の `StudyPlan` (apps/web/lib/api.ts) + 直近 `DailyProgress` 配列
- * - 振る舞い: 過去日の未消化問題数 (debt) を、`today` 以降の未来日にグリーディに振り分ける
- * - 制約: 1 日あたりの上限 = `max(originalQuestionCount, baseCap) * boost`
- *   （元計画のサイズを大きく超えない範囲で吸収）
+ * - v1.0: 過去日 debt を未来日にグリーディ (日付昇順) 振り分け
+ * - v1.5: ユーザの D&D による manualMoves を先に適用
+ * - v2.0: PerformanceProfile を入力すると、未来日を「曜日ペース重み × 弱点重み」で
+ *         並べ替えてから debt を充填。ユーザが実績を出している曜日 / 弱いカテゴリを
+ *         優先的に詰める。
+ *
  * - 試験日 (`plan.examDate`) を超える日には絶対に積まない（overflowed として返す）
- * - 純粋関数。I/O ゼロ。ゴールデンテスト容易。
+ * - 純粋関数。I/O ゼロ。
  *
  * 設計書: docs/02_design/20_DynamicReplanningEngine.md §13 (Phase 1 MVP)
- * 関連 Issue: #188 (P2-A-2)
+ * 関連 Issue: #188 (P2-A-2), #222 (v2.0)
  */
 
 import type { StudyPlan } from '@/lib/api';
+import type { PerformanceProfile } from '@/lib/types/performanceProfile';
 import type { DailyProgress } from '@ipa-lab/shared';
 
 export interface ReplanOptions {
@@ -53,7 +56,7 @@ export interface ReplanResult {
     diff: ReplanDiff;
     warnings: string[];
     generatedAt: string;
-    algorithmVersion: '1.0' | '1.5';
+    algorithmVersion: '1.0' | '1.5' | '2.0';
 }
 
 /**
@@ -74,6 +77,8 @@ export interface ReplanInput {
     today: string;
     /** v1.5: タスク単位の手動移動指示。空配列または未指定なら v1.0 と同等の挙動 */
     manualMoves?: ManualMove[];
+    /** v2.0: PerformanceProfile を渡すと曜日ペース × 弱点重み付きで再配分する */
+    profile?: PerformanceProfile;
     options?: ReplanOptions;
 }
 
@@ -100,7 +105,14 @@ export function replan(input: ReplanInput): ReplanResult {
     const moved: ReplanMove[] = [];
     const overflowed: ReplanOverflow[] = [];
 
-    type DayRef = { weekIdx: number; taskIdx: number; date: string; planned: number; cap: number };
+    type DayRef = {
+        weekIdx: number;
+        taskIdx: number;
+        date: string;
+        planned: number;
+        cap: number;
+        category?: string;
+    };
     const futureDays: DayRef[] = [];
     const pastDebts: { date: string; debt: number }[] = [];
 
@@ -117,12 +129,24 @@ export function replan(input: ReplanInput): ReplanResult {
             } else if (task.date <= plan.examDate) {
                 const planned = task.questionCount;
                 const cap = Math.max(opts.baseCapacity, Math.ceil(planned * opts.capacityBoost));
-                futureDays.push({ weekIdx: wi, taskIdx: ti, date: task.date, planned, cap });
+                futureDays.push({
+                    weekIdx: wi,
+                    taskIdx: ti,
+                    date: task.date,
+                    planned,
+                    cap,
+                    category: task.targetCategory,
+                });
             }
         });
     });
 
     futureDays.sort((a, b) => a.date.localeCompare(b.date));
+
+    // v2.0: profile があれば日付順 → 重み降順に並べ替えて充填する
+    const fillOrder = input.profile
+        ? rankDaysByProfileWeight([...futureDays], input.profile)
+        : futureDays;
 
     // 各 future day の現在割当量
     const assigned = new Map<string, number>();
@@ -158,11 +182,11 @@ export function replan(input: ReplanInput): ReplanResult {
         manualMovesApplied += 1;
     }
 
-    // --- 2. debt をグリーディに未来日へ詰め込む ---------------------------------------
+    // --- 2. debt をグリーディに未来日へ詰め込む (v2.0 では重み順) ---------------------
     let remaining = totalDebt;
     for (const debt of pastDebts) {
         let toRedistribute = debt.debt;
-        for (const day of futureDays) {
+        for (const day of fillOrder) {
             if (toRedistribute === 0) break;
             const cur = assigned.get(day.date)!;
             const room = day.cap - cur;
@@ -225,6 +249,48 @@ export function replan(input: ReplanInput): ReplanResult {
         },
         warnings,
         generatedAt: now,
-        algorithmVersion: manualMoves.length > 0 ? '1.5' : '1.0',
+        algorithmVersion: input.profile ? '2.0' : manualMoves.length > 0 ? '1.5' : '1.0',
     };
+}
+
+/**
+ * v2.0: futureDays を「曜日ペース重み × 弱点重み」の降順で並べ替えて返す。
+ *
+ * - paceWeight = paceByWeekday[dow] / mean(paceByWeekday)  (mean=0 の場合 1.0)
+ * - weaknessWeight = カテゴリ正答率が WEAKNESS_THRESHOLD 未満で WEAKNESS_BOOST、それ以外 1.0
+ * - weight = paceWeight * weaknessWeight
+ * - 重みが同じなら日付昇順 (元の順序保持)
+ *
+ * 弱点しきい値はとりあえず 60% (0.6)。実装着手時のメモ通り。
+ */
+const WEAKNESS_THRESHOLD = 0.6;
+const WEAKNESS_BOOST = 1.5;
+
+function rankDaysByProfileWeight<T extends { date: string; category?: string }>(
+    days: T[],
+    profile: PerformanceProfile,
+): T[] {
+    const paceMean = mean(profile.paceByWeekday);
+    const accuracyMap = new Map<string, number>();
+    for (const c of profile.accuracyByCategory) accuracyMap.set(c.category, c.accuracy);
+
+    const weighted = days.map((day, idx) => {
+        const dow = new Date(`${day.date}T00:00:00.000Z`).getUTCDay();
+        const paceWeight = paceMean > 0 ? profile.paceByWeekday[dow] / paceMean : 1;
+        const acc = day.category ? accuracyMap.get(day.category) : undefined;
+        const weaknessWeight =
+            acc !== undefined && acc < WEAKNESS_THRESHOLD ? WEAKNESS_BOOST : 1;
+        return { day, idx, weight: paceWeight * weaknessWeight };
+    });
+
+    weighted.sort((a, b) => {
+        if (b.weight !== a.weight) return b.weight - a.weight;
+        return a.idx - b.idx;
+    });
+    return weighted.map((w) => w.day);
+}
+
+function mean(arr: number[]): number {
+    if (arr.length === 0) return 0;
+    return arr.reduce((s, v) => s + v, 0) / arr.length;
 }

--- a/apps/web/lib/profile/buildPerformanceProfile.ts
+++ b/apps/web/lib/profile/buildPerformanceProfile.ts
@@ -1,0 +1,230 @@
+/**
+ * PerformanceProfile 生成 (#218 / v2.0 MVP3)
+ *
+ * 入力:
+ *   - dailyProgresses: 過去28日の DailyProgress[]
+ *   - records: 過去28日の LearningRecord[] (カテゴリ別正答率の算出用)
+ *   - plan: 現在の StudyPlan (達成率の planned 算出用)
+ *   - today: 基準日 (YYYY-MM-DD UTC)
+ *
+ * すべての算出ロジックを副作用ゼロの純粋関数として実装し、ユニットテストで網羅する。
+ */
+
+import type { LearningRecord, DailyProgress } from '@ipa-lab/shared';
+import type { StudyPlan } from '@/lib/types/studyPlan';
+import type { PerformanceProfile, CategoryAccuracy } from '@/lib/types/performanceProfile';
+
+const WINDOW_DAYS = 28;
+const RECENT_DAYS = 7;
+const ON_FIRE_THRESHOLD = 1.3;
+
+export interface BuildPerformanceProfileInput {
+    userId: string;
+    dailyProgresses: DailyProgress[];
+    records: LearningRecord[];
+    plan?: StudyPlan;
+    /** 基準日 (YYYY-MM-DD)。未指定時は new Date() の UTC 日付。 */
+    today?: string;
+    /** 集計時刻 (テスト固定用)。 */
+    now?: () => string;
+}
+
+/** UTC 基準で YYYY-MM-DD を返す */
+function todayKey(): string {
+    const d = new Date();
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+/** YYYY-MM-DD を UTC Date に変換 */
+function parseDate(date: string): Date {
+    return new Date(`${date}T00:00:00.000Z`);
+}
+
+/** UTC 日付に n 日加算した YYYY-MM-DD を返す */
+function addDays(date: string, n: number): string {
+    const d = parseDate(date);
+    d.setUTCDate(d.getUTCDate() + n);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+/** YYYY-MM-DD の曜日 (0=日 .. 6=土) を UTC で返す */
+function weekday(date: string): number {
+    return parseDate(date).getUTCDay();
+}
+
+/** plan の dailyTasks を date -> plannedQuestionCount に展開 */
+function buildPlannedMap(plan: StudyPlan | undefined): Record<string, number> {
+    const map: Record<string, number> = {};
+    if (!plan) return map;
+    for (const week of plan.weeklySchedule ?? []) {
+        for (const task of week.dailyTasks ?? []) {
+            map[task.date] = (map[task.date] ?? 0) + (task.questionCount ?? 0);
+        }
+    }
+    return map;
+}
+
+/**
+ * 曜日別ペース (paceByWeekday) を算出。
+ * 過去28日のうち学習記録 (questionCount > 0) のある日のみで平均を取る。
+ * 学習日 0 の曜日は 0 を返す。
+ */
+export function calcPaceByWeekday(progresses: DailyProgress[]): number[] {
+    const sums = new Array<number>(7).fill(0);
+    const counts = new Array<number>(7).fill(0);
+    for (const p of progresses) {
+        if (p.questionCount <= 0) continue;
+        const w = weekday(p.date);
+        sums[w] += p.questionCount;
+        counts[w] += 1;
+    }
+    return sums.map((s, i) => (counts[i] === 0 ? 0 : s / counts[i]));
+}
+
+/**
+ * 直近 n 日の達成率と末尾連続「絶好調」(>130%) 日数を算出。
+ * 達成率 = sum(actual) / sum(planned)。planned 0 → 0。
+ */
+export function calcRecentAchievement(
+    progresses: DailyProgress[],
+    plannedMap: Record<string, number>,
+    today: string,
+    days: number = RECENT_DAYS
+): { rate: number; consecutiveOnFireDays: number } {
+    let actualSum = 0;
+    let plannedSum = 0;
+    const dailyRate: { date: string; rate: number }[] = [];
+
+    for (let i = 0; i < days; i += 1) {
+        const date = addDays(today, -i);
+        const planned = plannedMap[date] ?? 0;
+        const actual = progresses.find((p) => p.date === date)?.questionCount ?? 0;
+        actualSum += actual;
+        plannedSum += planned;
+        const r = planned > 0 ? actual / planned : 0;
+        dailyRate.push({ date, rate: r });
+    }
+
+    const rate = plannedSum > 0 ? actualSum / plannedSum : 0;
+
+    // 末尾連続 (today から過去に向かって) >130% カウント
+    let consecutive = 0;
+    for (const d of dailyRate) {
+        if (d.rate > ON_FIRE_THRESHOLD) consecutive += 1;
+        else break;
+    }
+
+    return { rate, consecutiveOnFireDays: consecutive };
+}
+
+/** カテゴリ別正答率を集計 */
+export function calcAccuracyByCategory(records: LearningRecord[]): Record<string, CategoryAccuracy> {
+    const acc: Record<string, { total: number; correct: number }> = {};
+    for (const r of records) {
+        const key = r.category || 'unknown';
+        if (!acc[key]) acc[key] = { total: 0, correct: 0 };
+        acc[key].total += 1;
+        if (r.isCorrect) acc[key].correct += 1;
+    }
+    const out: Record<string, CategoryAccuracy> = {};
+    for (const [k, v] of Object.entries(acc)) {
+        out[k] = {
+            total: v.total,
+            correct: v.correct,
+            rate: v.total > 0 ? v.correct / v.total : 0,
+        };
+    }
+    return out;
+}
+
+/**
+ * 学習継続率と末尾連続学習日数。
+ * - continuityRate = 過去28日で questionCount > 0 の日数 / 28
+ * - consecutiveStudyDays = today から過去に連続して学習した日数 (1日でも空けば終了)
+ */
+export function calcContinuity(
+    progresses: DailyProgress[],
+    today: string
+): { continuityRate: number; consecutiveStudyDays: number } {
+    const studied = new Set<string>();
+    for (const p of progresses) {
+        if (p.questionCount > 0) studied.add(p.date);
+    }
+    let count = 0;
+    for (let i = 0; i < WINDOW_DAYS; i += 1) {
+        if (studied.has(addDays(today, -i))) count += 1;
+    }
+    let consecutive = 0;
+    for (let i = 0; i < WINDOW_DAYS; i += 1) {
+        if (studied.has(addDays(today, -i))) consecutive += 1;
+        else break;
+    }
+    return { continuityRate: count / WINDOW_DAYS, consecutiveStudyDays: consecutive };
+}
+
+/**
+ * ペース比 γ = 直近7日 / 過去7-14日。
+ * 過去7-14日が 0 の場合は 1.0 を返す。
+ */
+export function calcPaceRatio(progresses: DailyProgress[], today: string): number {
+    let recent = 0;
+    let prev = 0;
+    for (let i = 0; i < RECENT_DAYS; i += 1) {
+        const date = addDays(today, -i);
+        const p = progresses.find((x) => x.date === date);
+        if (p) recent += p.questionCount;
+    }
+    for (let i = RECENT_DAYS; i < RECENT_DAYS * 2; i += 1) {
+        const date = addDays(today, -i);
+        const p = progresses.find((x) => x.date === date);
+        if (p) prev += p.questionCount;
+    }
+    if (prev === 0) return 1;
+    return recent / prev;
+}
+
+/**
+ * PerformanceProfile を構築。
+ */
+export function buildPerformanceProfile(input: BuildPerformanceProfileInput): PerformanceProfile {
+    const today = input.today ?? todayKey();
+    const now = input.now ?? (() => new Date().toISOString());
+
+    // 過去28日でフィルタ
+    const windowStart = addDays(today, -(WINDOW_DAYS - 1));
+    const progresses = input.dailyProgresses.filter((p) => p.date >= windowStart && p.date <= today);
+    const records = input.records.filter((r) => {
+        const dateKey = r.answeredAt.slice(0, 10);
+        return dateKey >= windowStart && dateKey <= today;
+    });
+
+    const plannedMap = buildPlannedMap(input.plan);
+
+    const paceByWeekday = calcPaceByWeekday(progresses);
+    const { rate: recentAchievementRate, consecutiveOnFireDays } = calcRecentAchievement(
+        progresses,
+        plannedMap,
+        today
+    );
+    const accuracyByCategory = calcAccuracyByCategory(records);
+    const { continuityRate, consecutiveStudyDays } = calcContinuity(progresses, today);
+    const paceRatio = calcPaceRatio(progresses, today);
+
+    return {
+        userId: input.userId,
+        generatedAt: now(),
+        paceByWeekday,
+        recentAchievementRate,
+        consecutiveOnFireDays,
+        accuracyByCategory,
+        continuityRate,
+        consecutiveStudyDays,
+        paceRatio,
+    };
+}

--- a/apps/web/lib/repositories/learningRecordRepository.ts
+++ b/apps/web/lib/repositories/learningRecordRepository.ts
@@ -28,6 +28,33 @@ export const learningRecordRepository = {
         return resources as LearningRecord[];
     },
 
+    /**
+     * 指定期間 (answeredAt が fromIso 以上 toIso 未満) の LearningRecord を返す。
+     * #224 v2.0 MVP3: PerformanceProfile が直近28日分しか必要としないため、
+     * Cosmos の RU/レイテンシ削減のために範囲を絞って取得する。
+     *
+     * fromIso/toIso は ISO datetime 文字列 (例: '2026-04-01T00:00:00.000Z')。
+     */
+    async findByUserIdInDateRange(
+        userId: string,
+        fromIso: string,
+        toIso: string,
+    ): Promise<LearningRecord[]> {
+        const container = await getContainer(this.containerName);
+        if (!container) throw new Error('Database not initialized');
+        const querySpec: SqlQuerySpec = {
+            query:
+                "SELECT * FROM c WHERE c.userId = @userId AND c.answeredAt >= @from AND c.answeredAt < @to",
+            parameters: [
+                { name: "@userId", value: userId },
+                { name: "@from", value: fromIso },
+                { name: "@to", value: toIso },
+            ],
+        };
+        const { resources } = await container.items.query(querySpec).fetchAll();
+        return resources as LearningRecord[];
+    },
+
     async listByUserId(userId: string): Promise<LearningRecord[]> {
         return this.findByUserId(userId);
     },

--- a/apps/web/lib/types/performanceProfile.ts
+++ b/apps/web/lib/types/performanceProfile.ts
@@ -6,7 +6,7 @@
  * - replan v2.0 (#222) の重み付け、ヘルスチェック (#220)、可視化UI (#219) で参照
  */
 
-/** 曜日別カテゴリ正答率の集計 */
+/** カテゴリ別正答率の集計 */
 export interface CategoryAccuracy {
     /** 解答数 */
     total: number;

--- a/apps/web/lib/types/performanceProfile.ts
+++ b/apps/web/lib/types/performanceProfile.ts
@@ -1,0 +1,55 @@
+/**
+ * PerformanceProfile (#218 / v2.0 適応型計画 MVP3)
+ *
+ * ユーザの実績シグナルを集約した型。
+ * - DailyProgress + LearningRecord + StudyPlan から純粋関数 `buildPerformanceProfile` で生成
+ * - replan v2.0 (#222) の重み付け、ヘルスチェック (#220)、可視化UI (#219) で参照
+ */
+
+/** 曜日別カテゴリ正答率の集計 */
+export interface CategoryAccuracy {
+    /** 解答数 */
+    total: number;
+    /** 正答数 */
+    correct: number;
+    /** 正答率 (0-1) */
+    rate: number;
+}
+
+export interface PerformanceProfile {
+    userId: string;
+    /** プロファイル生成時刻 (ISO) */
+    generatedAt: string;
+    /**
+     * 曜日別の平均解答ペース (questionCount/日)。
+     * 過去28日に学習記録のある日のみで平均を取る (学習しなかった日は分母に含めない)。
+     * index 0=日, 1=月, ..., 6=土
+     */
+    paceByWeekday: number[];
+    /**
+     * 直近7日の達成率。sum(actual) / sum(planned)。
+     * planned が 0 の場合は 0 を返す。
+     * 値域: 0 以上 (130%超え = 1.3 以上もありうる)
+     */
+    recentAchievementRate: number;
+    /**
+     * 直近7日のうち、達成率 > 130% を満たした連続日数 (末尾連続)。
+     * 「絶好調」(on_fire) ヘルス判定で「連続3日」を見るのに使用。
+     */
+    consecutiveOnFireDays: number;
+    /** カテゴリ別正答率 (LearningRecord.category キー) */
+    accuracyByCategory: Record<string, CategoryAccuracy>;
+    /**
+     * 学習継続率 (過去28日で学習した日数 / 28)。
+     * 値域: 0-1
+     */
+    continuityRate: number;
+    /** 過去28日における直近の連続学習日数 (末尾から数えて何日連続学習したか)。1日空きで途切れる。 */
+    consecutiveStudyDays: number;
+    /**
+     * ペース比 γ。直近7日 questionCount合計 / 過去7-14日 questionCount合計。
+     * 1.0 = 同等、1.0 超 = 加速、1.0 未満 = 減速。
+     * 過去7-14日が 0 の場合は 1.0 を返す (NaN 回避)。
+     */
+    paceRatio: number;
+}

--- a/apps/web/lib/types/planHealth.ts
+++ b/apps/web/lib/types/planHealth.ts
@@ -4,7 +4,7 @@
  * - 直近 7 日達成率と on_fire 連続日数からヘルスを判定
  * - AI 不使用の純粋関数で算出
  *
- * 関連: docs/02_design/22_AdaptiveStudyPlan.md (作成予定)
+ * 関連設計は docs/02_design/ 配下の学習計画系ドキュメントを参照
  */
 
 export type PlanHealthStatus =

--- a/apps/web/lib/types/planHealth.ts
+++ b/apps/web/lib/types/planHealth.ts
@@ -1,0 +1,41 @@
+/**
+ * 計画ヘルスチェック型定義 (v2.0 MVP3 / #220).
+ *
+ * - 直近 7 日達成率と on_fire 連続日数からヘルスを判定
+ * - AI 不使用の純粋関数で算出
+ *
+ * 関連: docs/02_design/22_AdaptiveStudyPlan.md (作成予定)
+ */
+
+export type PlanHealthStatus =
+    | 'on_track' // 🟢 達成率 >= 70%
+    | 'slight_delay' // 🟡 40% <= 達成率 < 70%
+    | 'major_delay' // 🔴 達成率 < 40%
+    | 'on_fire'; // 🚀 達成率 > 130% かつ 連続 3 日
+
+export type PlanHealthSuggestionKind =
+    | 'none' // 提案なし (順調)
+    | 'replan_recommended' // 遅延 → 再配分を提案
+    | 'celebrate_and_boost'; // 絶好調 → ペース上げ提案
+
+export interface PlanHealthSuggestion {
+    kind: PlanHealthSuggestionKind;
+    headline: string;
+    body: string;
+    /** UI が呼ぶアクション識別子 */
+    action: 'open_replan' | 'increase_pace' | null;
+}
+
+export interface PlanHealthResult {
+    status: PlanHealthStatus;
+    /** 直近 7 日達成率 (0..) */
+    achievementRate: number;
+    /** on_fire 連続日数 */
+    consecutiveOnFireDays: number;
+    /** ポップアップを出すべきか (純粋判定; スロットリングは UI 側) */
+    shouldNotify: boolean;
+    /** UI 表示用提案 */
+    suggestion: PlanHealthSuggestion;
+    /** 判定時刻 (ISO) */
+    evaluatedAt: string;
+}


### PR DESCRIPTION
## 概要
v2.0 MVP3 [P3-C] の核。`ReplanInput.profile` に `PerformanceProfile` を渡すと、debt 再配分を「曜日ペース重み × 弱点カテゴリ重み」で行う。

## アルゴリズム
未来日 `D` の充填重みを以下で算出し、降順に並べてから既存のグリーディ詰め込みを行う:

```
paceWeight    = paceByWeekday[dow(D)] / mean(paceByWeekday)   // 0 の場合は 1.0
weaknessWeight = (D.targetCategory が弱点 (正答率 < 60%)) ? 1.5 : 1.0
weight = paceWeight × weaknessWeight
```

→ 「ユーザが実績を出している曜日」と「弱点カテゴリの日」に優先的に詰まる。

## 互換性
- profile 未指定: 従来通り日付昇順 → algorithmVersion=`'1.0'` / `'1.5'`
- profile 指定: algorithmVersion=`'2.0'`
- 既存 16 テストはすべて green

## テスト
- 単体テスト **5 件** 追加 / 全体 **594 件** green
  - 曜日ペース重みで土日に詰まる
  - 弱点カテゴリに詰まる
  - profile 無しは v1.0 互換
  - paceByWeekday 全 0 でも例外なし

## ベース
このPRは feat/220-plan-health-check をベースにしています (依存: #218, #220)。
#220 マージ後に base を main へ切り替えてください。

Closes #222
Depends on #218, #220