### PR TITLE
fix(exam): Cosmos 同期漏れ時に午後試験が表示されない問題を修正（filesystem fallback 本番有効化）

### DIFF
--- a/apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx
+++ b/apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx
@@ -71,10 +71,11 @@ export default async function ExamQuestionPage({ params }: { params: Promise<{ y
         console.error(`[Page] Cosmos query failed for examId=${examId}:`, e instanceof Error ? e.message : e);
     }
 
-    // Filesystem フォールバック: ローカル/開発時のみ有効。
-    // 本番(standalone build)では packages/data が同梱されないため事実上動作しない。
-    // 同期漏れを本番で隠蔽しないよう、明示的に開発環境のみ実行する。
-    if (questions.length === 0 && process.env.NODE_ENV !== 'production') {
+    // Filesystem フォールバック: 全環境で有効。
+    // packages/data の JSON は next.config.js の outputFileTracingIncludes で
+    // standalone build に同梱される。Cosmos 同期漏れ・接続障害時の最終防衛線。
+    // observability: fallback が発動した場合は warn を出して根本原因 (Cosmos 欠損 / 同期漏れ) の追跡可能性を確保する。
+    if (questions.length === 0) {
         try {
             const fsData = await getExamData(examId);
             if (fsData && !Array.isArray(fsData)) {
@@ -87,7 +88,10 @@ export default async function ExamQuestionPage({ params }: { params: Promise<{ y
                 questions = fsData as unknown as Question[];
             }
             if (questions.length > 0) {
-                console.info(`[Page] Loaded ${questions.length} questions from filesystem fallback for ${examId} (dev only).`);
+                console.warn(
+                    `[Page] Filesystem fallback engaged for examId=${examId} (loaded ${questions.length} questions). ` +
+                    `Cosmos status=${loadStatus}. Investigate sync gap or DB outage.`
+                );
             }
         } catch (e) {
             console.warn(`[Page] FS Data load failed for ${examId}:`, e instanceof Error ? e.message : e);

--- a/apps/web/app/(main)/exam/[year]/[type]/page.tsx
+++ b/apps/web/app/(main)/exam/[year]/[type]/page.tsx
@@ -19,14 +19,17 @@ export default async function ExamEntrancePage({ params }: { params: Promise<{ y
 
     // Fetch Data
     let questions: Question[] = [];
+    let cosmosFailed = false;
     try {
         const data = await questionRepository.listByExamId(examId);
         questions = data as unknown as Question[];
     } catch (e) {
-        // CosmosDB 失敗時は無視
+        cosmosFailed = true;
+        console.error(`[Page] Cosmos query failed for examId=${examId}:`, e instanceof Error ? e.message : e);
     }
 
-    // ファイルシステムフォールバック (ローカル開発・DB未接続時)
+    // Filesystem フォールバック: 全環境で有効。Cosmos 同期漏れ・接続障害時の最終防衛線。
+    // observability: fallback が発動した場合は warn を出して根本原因の追跡可能性を確保する。
     if (questions.length === 0) {
         try {
             const fsData = await getExamData(examId);
@@ -42,8 +45,14 @@ export default async function ExamEntrancePage({ params }: { params: Promise<{ y
                 // Form A: 配列
                 questions = fsData as unknown as Question[];
             }
+            if (questions.length > 0) {
+                console.warn(
+                    `[Page] Filesystem fallback engaged for examId=${examId} (loaded ${questions.length} questions). ` +
+                    `cosmosFailed=${cosmosFailed}. Investigate sync gap or DB outage.`
+                );
+            }
         } catch (e) {
-            console.warn(`[Page] FS Data load failed for ${examId}.`);
+            console.warn(`[Page] FS Data load failed for ${examId}:`, e instanceof Error ? e.message : e);
         }
     }
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -8,6 +8,13 @@ const nextConfig = {
     outputFileTracingRoot: path.join(__dirname, '../../'),
     transpilePackages: ["@ipa-lab/shared"],
     reactStrictMode: true,
+    // standalone build に packages/data の問題JSONを同梱する。
+    // ssg-helper.ts は cwd 相対の動的パスで読むため Next.js のトレース対象外となる。
+    // Cosmos 同期漏れ時のフォールバック (apps/web/app/(main)/exam/...) で必須。
+    outputFileTracingIncludes: {
+        '/exam/**': ['../../packages/data/data/questions/**/*.json'],
+        '/api/**': ['../../packages/data/data/questions/**/*.json'],
+    },
     // Next.js 15: serverComponentsExternalPackages renamed to serverExternalPackages
     serverExternalPackages: [
         '@azure/cosmos',


### PR DESCRIPTION
## 背景

staging で `/exam/SA-2024-Spring-PM1/PM1/1` にアクセスすると「この試験のデータが見つかりません」が表示される問題を報告いただいた。

## 根本原因

二段階の防壁が両方無効化されていた：

1. **Cosmos 同期漏れ** (推定): SA-2024-Spring-PM1 の問題が共用 Cosmos に投入されていない可能性が高い（ローカルにはデータ 3 問あり）。
2. **Filesystem fallback が本番で無効**: PR #210 で `process.env.NODE_ENV !== 'production'` ガードが入り、staging/prod で fallback が動かなくなっていた。
3. **standalone build に JSON 未同梱**: `next.config.js` の `outputFileTracingIncludes` 未設定のため、`packages/data/data/questions/**` が standalone bundle から除外されていた（`ssg-helper.ts` が動的パスで読むため Next.js の自動トレース対象外）。

## 修正内容

| ファイル | 変更 |
|---|---|
| `apps/web/app/(main)/exam/[year]/[type]/[qNo]/page.tsx` | `NODE_ENV !== 'production'` ガードを撤廃。fallback 発動時は `console.warn` で根本原因追跡可能に |
| `apps/web/app/(main)/exam/[year]/[type]/page.tsx` | エントランス側も同等の warn ログ／Cosmos エラー捕捉を統一（観測性向上） |
| `apps/web/next.config.js` | `outputFileTracingIncludes` を追加し `packages/data/data/questions/**/*.json` を `/exam/**` と `/api/**` 配下の standalone bundle に同梱 |

## 検証

- `npm run build`: ✅ 成功
- standalone bundle 内に **179 試験ディレクトリ** が含まれることを確認（SA-2024-Spring-PM1/questions_transformed.json 31451 bytes 含む）
- `vitest run` (apps/web): ✅ 568 / 568 tests passed

## 観測性

fallback が発動すると Application Insights に以下のログが残るので、**「fallback で動いている = Cosmos 同期漏れがある」** ことを早期発見できる:

```
[Page] Filesystem fallback engaged for examId=XXX (loaded N questions). cosmosFailed=false. Investigate sync gap or DB outage.
```

## フォローアップ (別 Issue 化推奨)

- [ ] SA-2024-Spring-PM1 を含む Cosmos 全試験データの同期実態を Azure Portal で確認
- [ ] sync-db.ts を CI で自動実行する仕組み（手動実行依存からの脱却）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>