### PR TITLE
fix(dashboard): statusCard.fullWidthCard が span 4 に縮むデグレ修正

### DIFF
--- a/.github/hooks/self-inspect.ps1
+++ b/.github/hooks/self-inspect.ps1
@@ -12,6 +12,8 @@
 #       → Application Insights に流れず障害調査が困難になる (#229)
 #   R3. .fullWidthCard 等の重要 CSS クラスがメディアクエリ内にしか
 #       定義されていない (モバイル幅でデッドスペース発生)
+#   R4. .todayMissionPriority 等のレイアウト特殊クラスが @media 内で
+#       grid-column: span 12 に上書きされている (PR 混入によるデグレ再発防止)
 #
 # 引数:
 #   -Mode start|end   どちらのフェーズで呼ばれたか (出力タグの違いだけ)
@@ -124,8 +126,60 @@ Get-ChildItem -Path $WebRoot -Filter '*.module.css' -Recurse | ForEach-Object {
 }
 
 # ---------------------------------------------------------------------------
-# レポート出力
+# R4: レイアウト特殊クラスが @media 内で grid-column: span 12 に上書きされていないか
+#     (デグレパターン: .todayMissionPriority は .statusCard の span 4 を継承すべき)
+# R5: @media 内の単一クラスセレクタ (例: .statusCard) が、トップレベルで定義された
+#     組合せクラス (.statusCard.fullWidthCard) の grid-column を意図せず打ち消すパターン
+#     → @media 内では .X:not(.fullWidthCard) のように除外する必要がある
 # ---------------------------------------------------------------------------
+$r4Targets = @(
+    @{ File = 'DashboardClient.module.css'; Class = 'todayMissionPriority' }
+)
+Get-ChildItem -Path $WebRoot -Filter '*.module.css' -Recurse | ForEach-Object {
+    $cssFile = $_
+    foreach ($t in $r4Targets) {
+        if ($cssFile.Name -ne $t.File) { continue }
+        $raw = Get-Content -LiteralPath $cssFile.FullName -Raw
+        # @media ブロック内に .todayMissionPriority { ... grid-column ... } があるか
+        $mediaBlocks = [regex]::Matches($raw, '(?s)@media[^{]+\{(?:[^{}]|\{[^{}]*\})*\}')
+        foreach ($mb in $mediaBlocks) {
+            $innerClass = [regex]::Matches($mb.Value, "(?s)\.$($t.Class)\s*\{([^}]*)\}")
+            foreach ($ic in $innerClass) {
+                if ($ic.Groups[1].Value -match 'grid-column') {
+                    Add-Finding -Rule 'R4-css-media-grid-override' -Severity 'High' `
+                        -File $cssFile.FullName `
+                        -Detail ".$($t.Class) が @media 内で grid-column を上書きしています (デグレの原因になります)"
+                }
+            }
+        }
+    }
+}
+
+# R5: @media 内の statusCard / heatmapCard 等が fullWidthCard を打ち消すパターン
+$r5SusClasses = @('statusCard', 'heatmapCard', 'historyCard', 'levelCard')
+Get-ChildItem -Path $WebRoot -Filter 'DashboardClient.module.css' -Recurse | ForEach-Object {
+    $cssFile = $_
+    $raw = Get-Content -LiteralPath $cssFile.FullName -Raw
+    $mediaBlocks = [regex]::Matches($raw, '(?s)@media[^{]+\{(?:[^{}]|\{[^{}]*\})*\}')
+    foreach ($mb in $mediaBlocks) {
+        foreach ($cls in $r5SusClasses) {
+            # @media 内に `.X { ... grid-column ... }` が裸で書かれているかをチェック
+            # (`.X:not(...)` 形式は OK)
+            $bareSelector = [regex]::Matches($mb.Value, "(?s)(^|[\s,\}])\.$cls\s*\{([^}]*)\}")
+            foreach ($bs in $bareSelector) {
+                if ($bs.Groups[2].Value -match 'grid-column' -and
+                    $raw -match "\.$cls\.fullWidthCard|\.fullWidthCard\.$cls") {
+                    # トップレベルで .X.fullWidthCard が登場しているのに、@mediaで .X 単独で grid-column を定義
+                    Add-Finding -Rule 'R5-css-media-fullwidth-shadow' -Severity 'High' `
+                        -File $cssFile.FullName `
+                        -Detail ".$cls が @media 内で grid-column を裸定義し .fullWidthCard を打ち消す可能性 (推奨: .${cls}:not(.fullWidthCard))"
+                }
+            }
+        }
+    }
+}
+
+
 $tag = if ($Mode -eq 'start') { 'SESSION-START' } else { 'SESSION-END' }
 Write-Host ""
 Write-Host "## [self-inspect $tag] 自己点検レポート"
@@ -138,15 +192,15 @@ if ($findings.Count -eq 0) {
 
 Write-Host "⚠ 検出件数: $($findings.Count) 件"
 Write-Host ""
-Write-Host "| Severity | Rule | File | Detail |"
-Write-Host "|---|---|---|---|"
+Write-Host '| Severity | Rule | File | Detail |'
+Write-Host '|----------|------|------|--------|'
 foreach ($f in $findings) {
     $rel = $f.File.Replace($RepoRoot.Path, '').TrimStart('\', '/')
     Write-Host "| $($f.Severity) | $($f.Rule) | $rel | $($f.Detail) |"
 }
 
 Write-Host ""
-Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動"
+Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除"
 
 if ($FailOnFinding) { exit 1 }
 exit 0

--- a/apps/web/app/api/ai/scoring/afternoon/essay/v2/route.ts
+++ b/apps/web/app/api/ai/scoring/afternoon/essay/v2/route.ts
@@ -49,6 +49,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   try {
     body = RequestSchema.parse(await req.json());
   } catch (err) {
+    console.error('[essay-v2] Invalid request body:', err instanceof Error ? err.message : String(err));
     return NextResponse.json(
       { error: 'EMPTY_ANSWER', details: err instanceof z.ZodError ? err.errors : String(err) },
       { status: 422 },
@@ -113,6 +114,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       return NextResponse.json({ ...((completeEvt.data as object) ?? {}), partialErrors: errors });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      console.error('[essay-v2] LLM batch error:', message);
       return NextResponse.json({ error: 'LLM_TIMEOUT', message }, { status: 504 });
     }
   }

--- a/apps/web/app/api/ai/scoring/afternoon/short-answer/v2/route.ts
+++ b/apps/web/app/api/ai/scoring/afternoon/short-answer/v2/route.ts
@@ -42,6 +42,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     const json = await req.json();
     body = RequestSchema.parse(json);
   } catch (err) {
+    console.error('[short-answer-v2] Invalid request body:', err instanceof Error ? err.message : String(err));
     return NextResponse.json(
       {
         error: 'EMPTY_ANSWER',
@@ -75,6 +76,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       return NextResponse.json({ ...((completeEvt.data as object) ?? {}), partialErrors: errors });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      console.error('[short-answer-v2] LLM batch error:', message);
       return NextResponse.json({ error: 'LLM_TIMEOUT', message }, { status: 504 });
     }
   }

--- a/apps/web/app/api/exam-progress/route.ts
+++ b/apps/web/app/api/exam-progress/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
             }
             return NextResponse.json(resource);
         } catch (e: any) {
-            // 404 is fine, return empty
+            if (e.code !== 404) console.error('[exam-progress] Unexpected read error:', e);
             if (e.code === 404) {
                 return NextResponse.json({
                     id,
@@ -97,6 +97,7 @@ export async function POST(request: NextRequest) {
                 };
             }
         } catch (e) {
+            console.error('[exam-progress] Failed to read existing progress, using default:', e);
             progress = {
                 id,
                 userId,

--- a/apps/web/app/api/exams/[examId]/questions/route.ts
+++ b/apps/web/app/api/exams/[examId]/questions/route.ts
@@ -36,6 +36,7 @@ export async function GET(
 
         return NextResponse.json(safeQuestions);
     } catch (error) {
+        console.error('[exam-questions] Failed to fetch questions:', error);
         return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
     }
 }

--- a/apps/web/app/api/profile/performance/route.ts
+++ b/apps/web/app/api/profile/performance/route.ts
@@ -99,6 +99,7 @@ export async function GET(_request: NextRequest) {
         return NextResponse.json({ profile });
     } catch (e) {
         const message = e instanceof Error ? e.message : 'Internal Error';
+        console.error('[profile/performance] Error:', message);
         return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
     }
 }

--- a/apps/web/app/api/user-progress/daily/recompute/route.ts
+++ b/apps/web/app/api/user-progress/daily/recompute/route.ts
@@ -78,6 +78,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ upsertedCount, range: { from, to } });
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Internal Error';
+    console.error('[user-progress/daily/recompute] Error:', message);
     return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
   }
 }

--- a/apps/web/app/api/user-progress/daily/route.ts
+++ b/apps/web/app/api/user-progress/daily/route.ts
@@ -81,6 +81,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ items, summary });
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Internal Error';
+    console.error('[user-progress/daily] Error:', message);
     return NextResponse.json({ error: 'INTERNAL_ERROR', message }, { status: 500 });
   }
 }

--- a/apps/web/components/features/dashboard/DashboardClient.module.css
+++ b/apps/web/components/features/dashboard/DashboardClient.module.css
@@ -323,11 +323,15 @@
 }
 
 @media (min-width: 1024px) {
-    .statusCard {
+    /* fullWidthCard を持つ statusCard (例: 学習目標カード) は span 12 を保持する。
+     * バグ修正: 以前は .statusCard { span 4 } が .fullWidthCard を上書きし、
+     * 学習目標カードが幅 4 に縮んで右側にデッドスペースが発生していた。
+     */
+    .statusCard:not(.fullWidthCard) {
         grid-column: span 4;
     }
 
-    .heatmapCard {
+    .heatmapCard:not(.fullWidthCard) {
         grid-column: span 4;
     }
 


### PR DESCRIPTION
## 課題
ユーザー報告: `shikaku-no.com/dashboard` で並び順と学習状況の幅がデグレしている。先のデッドスペース修正 (#232 / commit 160cd61) では解消されていなかった。

## 根本原因
`DashboardClient.module.css` の `@media (min-width: 1024px)` 内で:
```css
.statusCard { grid-column: span 4; }
```
が裸セレクタで定義されていた。これがトップレベル定義の
```css
.fullWidthCard { grid-column: span 12; }
```
を CSS specificity 同点 + ソース順で上書き。結果として **学習目標カード (`statusCard + fullWidthCard`)** がデスクトップで span 4 に縮み、右側に8カラム分のデッドスペースが発生。`order: 7` で最後に置きたいのに span 4 のせいで他の span 4 カードと同じ行に流れ込み、並び順も実質的に崩れていた。

## 修正
- `@media` 内のセレクタを `.statusCard:not(.fullWidthCard)` に変更
- 同パターン予防のため `.heatmapCard:not(.fullWidthCard)` も適用

## 横展開
- `self-inspect.ps1` に **R5ルール** を追加: 裸の `.X` が `.X.fullWidthCard` を打ち消すパターンを自動検出
- アプリ全体の `*.module.css` を sub-agent で監査し、ダッシュボード以外で同等の致命的バグは確認されず

## 副次修正 (R2 取りこぼし救済)
前回コミット 1659bcc で staged されていなかった API route の `console.error` 追加分を本PRに含める:
- `essay/v2` / `short-answer/v2` / `exam-progress` / `exams[examId]/questions`
- `profile/performance` / `user-progress/daily` / `daily/recompute`

## 検証
- `self-inspect.ps1`: 検出 0 件
- ローカル test: 626/626 PASS（前回コミット時点）
- 期待レイアウト: 1段目 今日のミッション(span 4) + 通算正答率(span 4) + ヒートマップ(span 4) / 2-4段目 levelCard / 今月 / 履歴 (各 span 12) / 5段目 学習目標 (span 12, order 7)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>