### PR TITLE
fix(dashboard): PerformanceInsightsがspan 1で潰れるデグレ修正

### DIFF
--- a/apps/web/components/features/dashboard/DashboardClient.tsx
+++ b/apps/web/components/features/dashboard/DashboardClient.tsx
@@ -768,6 +768,7 @@ export default function DashboardClient() {
                     profile={performanceProfile}
                     loading={performanceProfileLoading}
                     error={performanceProfileError}
+                    className={styles.fullWidthCard}
                 />
                 <section className={`${styles.card} ${styles.levelCard} ${styles.fullWidthCard} ${styles.collapsibleSection}`}>
                     {renderCollapseToggle('level', 'レベル情報', 'light')}

--- a/apps/web/components/features/dashboard/PerformanceInsights.tsx
+++ b/apps/web/components/features/dashboard/PerformanceInsights.tsx
@@ -22,6 +22,12 @@ interface PerformanceInsightsProps {
     loading: boolean;
     error: string | null;
     onRetry?: () => void;
+    /**
+     * 親 (DashboardClient) のグリッドレイアウト用クラス (例: fullWidthCard) を
+     * このコンポーネントの `<section>` に付与するためのフック。
+     * これがないと CSS Grid 内で `grid-column: auto` (span 1) になりレイアウトが崩れる。
+     */
+    className?: string;
 }
 
 interface PaceMood {
@@ -61,6 +67,7 @@ export default function PerformanceInsights({
     loading,
     error,
     onRetry,
+    className,
 }: PerformanceInsightsProps) {
     const [collapsed, setCollapsed] = useState(false);
 
@@ -78,16 +85,17 @@ export default function PerformanceInsights({
     }, [profile]);
 
     if (!enabled) return null;
+    const rootClass = className ? `${styles.card} ${className}` : styles.card;
     if (loading && !profile) {
         return (
-            <section className={styles.card} aria-busy="true">
+            <section className={rootClass} aria-busy="true">
                 <div className={styles.empty}>📊 学習ペースを集計中...</div>
             </section>
         );
     }
     if (error && !profile) {
         return (
-            <section className={styles.card} role="alert">
+            <section className={rootClass} role="alert">
                 <div className={styles.empty}>
                     ⚠️ 学習ペースの取得に失敗しました ({error})
                     {onRetry && (
@@ -104,7 +112,7 @@ export default function PerformanceInsights({
     }
     if (!profile) {
         return (
-            <section className={styles.card}>
+            <section className={rootClass}>
                 <div className={styles.empty}>
                     📊 まだ学習データが少ないため、ペースを表示できません。
                     <br />
@@ -120,7 +128,7 @@ export default function PerformanceInsights({
     const hasAnyCategory = sortedCategories.length > 0;
 
     return (
-        <section className={styles.card} aria-label="あなたの学習ペース">
+        <section className={rootClass} aria-label="あなたの学習ペース">
             <div className={styles.header}>
                 <div>
                     <h2 className={styles.title}>📊 あなたの学習ペース</h2>


### PR DESCRIPTION
## 問題
ステージングのダッシュボードで「あなたの学習ペース」カードが極端に縦長・幅狭になり、1段目のレイアウトが崩壊する深刻なデグレが発生していた（PR #248 マージ後に発覚）。

## 根本原因
`<PerformanceInsights />` は独自の CSS Module (`PerformanceInsights.module.css` の `.card`) を使用しており、親コンテナである `DashboardClient.module.css` の `.grid` (12カラムグリッド) 内で `grid-column` を一切宣言していなかった。
結果として `grid-column: auto` (= span 1) が適用され 1/12 幅に圧縮 → 隣接カードが auto-flow で意図しない位置に流れてレイアウト全体が崩壊していた。

これは PR #248 の `:not(.fullWidthCard)` 修正とは独立した問題で、#248 自体は意図通り機能している。今回の修正前から潜在していた不具合が、フルワイド系カードの順序が変わったことで顕在化した。

## 修正
1. `PerformanceInsights` が optional `className` prop を受け取れるよう拡張
2. 3つの早期リターン (loading/error/empty) と本体 `<section>` のすべてに rootClass (= `styles.card` + 渡された className) を適用
3. `DashboardClient` 側で `className={styles.fullWidthCard}` を渡し span 12 を保証

これにより PerformanceInsights は常にダッシュボード上部にフル幅で表示される。

## 影響範囲
- `apps/web/components/features/dashboard/PerformanceInsights.tsx`
- `apps/web/components/features/dashboard/DashboardClient.tsx`

## 検証
- `npx tsc --noEmit` パス
- self-inspect.ps1 (pre-push hook) パス

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>