### PR TITLE
fix: aiChat呼び出しに署名検証を追加

### DIFF
--- a/.github/hooks/self-inspect.ps1
+++ b/.github/hooks/self-inspect.ps1
@@ -49,6 +49,7 @@
 #   R36. 午後問題データに英語の設問文・説明文が混入するパターン
 #   R37. sync-db が FE 公開問題を秋期/午後として Exams に登録するパターン
 #   R38. 本番/Staging の App Service 設定から AI_CHAT_FUNCTION_URL が欠落するパターン
+#   R39. aiChat HMAC 署名用 AI_CHAT_FUNCTION_SECRET がデプロイ設定から欠落するパターン
 #
 # 引数:
 #   -Mode start|end   どちらのフェーズで呼ばれたか (出力タグの違いだけ)
@@ -537,6 +538,33 @@ if (Test-Path $azureWorkflowForR38) {
         Add-Finding -Rule 'R38-staging-ai-chat-function-url' -Severity 'High' `
             -File $azureWorkflowForR38 `
             -Detail 'Staging App Service 設定に AI_CHAT_FUNCTION_URL を含め、/api/score が East Asia から Gemini を直接呼ばないようにしてください'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# R39: aiChat 署名検証に必要な AI_CHAT_FUNCTION_SECRET が各デプロイ設定に含まれること
+#      (Function を保護しても Web 側または Function 側の設定漏れで採点が 503/500 になる再発防止)
+# ---------------------------------------------------------------------------
+if (Test-Path $azureWorkflowForR38) {
+    if ($prodSettings -notmatch 'AI_CHAT_FUNCTION_SECRET="\$\{\{ secrets\.AI_CHAT_FUNCTION_SECRET \}\}"') {
+        Add-Finding -Rule 'R39-prod-ai-chat-function-secret' -Severity 'High' `
+            -File $azureWorkflowForR38 `
+            -Detail '本番 App Service 設定に AI_CHAT_FUNCTION_SECRET を含め、aiChat への署名付きリクエストを生成できるようにしてください'
+    }
+    if ($stagingSettings -notmatch 'AI_CHAT_FUNCTION_SECRET="\$\{\{ secrets\.AI_CHAT_FUNCTION_SECRET \}\}"') {
+        Add-Finding -Rule 'R39-staging-ai-chat-function-secret' -Severity 'High' `
+            -File $azureWorkflowForR38 `
+            -Detail 'Staging App Service 設定に AI_CHAT_FUNCTION_SECRET を含め、aiChat への署名付きリクエストを生成できるようにしてください'
+    }
+}
+
+$aiFunctionWorkflowForR39 = Join-Path $RepoRoot '.github\workflows\azure-functions-ai.yml'
+if (Test-Path $aiFunctionWorkflowForR39) {
+    $aiFunctionWorkflowRaw = Get-Content -LiteralPath $aiFunctionWorkflowForR39 -Raw
+    if ($aiFunctionWorkflowRaw -notmatch 'AI_CHAT_FUNCTION_SECRET="\$\{\{ secrets\.AI_CHAT_FUNCTION_SECRET \}\}"') {
+        Add-Finding -Rule 'R39-function-ai-chat-function-secret' -Severity 'High' `
+            -File $aiFunctionWorkflowForR39 `
+            -Detail 'AI Function App 設定に AI_CHAT_FUNCTION_SECRET を含め、aiChat が署名検証できるようにしてください'
     }
 }
 
@@ -1193,7 +1221,7 @@ Write-Host "## [self-inspect $tag] 自己点検レポート"
 Write-Host ""
 
 if ($findings.Count -eq 0) {
-    Write-Host "✅ 検出された不整合はありません (R1 / R2 / R3 / R4 / R5 / R6 / R7 / R8 / R9 / R10 / R11 / R12 / R13 / R14 / R15 / R16 / R17 / R18 / R19 / R20 / R21 / R22 / R23 / R24 / R24b / R25 / R26 / R27 / R28 / R29 / R30 / R31 / R32 / R33 / R34 / R35 / R36 / R37 / R38)"
+    Write-Host "✅ 検出された不整合はありません (R1 / R2 / R3 / R4 / R5 / R6 / R7 / R8 / R9 / R10 / R11 / R12 / R13 / R14 / R15 / R16 / R17 / R18 / R19 / R20 / R21 / R22 / R23 / R24 / R24b / R25 / R26 / R27 / R28 / R29 / R30 / R31 / R32 / R33 / R34 / R35 / R36 / R37 / R38 / R39)"
     exit 0
 }
 
@@ -1207,7 +1235,7 @@ foreach ($f in $findings) {
 }
 
 Write-Host ""
-Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除 / R6 → error を弱点判定から除外 / R7 → 公式小問スコアを優先 / R8 → document-agent が docs/ を更新 / R9 → セッション進捗保存は currentSessionStats を使用 / R10 → Mermaid CODE_BLOCK マーカーを sanitizeMermaid で除去 / R11 → qNo 欠損を 99 にせず同期失敗として扱う / R12 → tracked 設定から接続文字列・API キー実値を除去 / R13 → download.ts で content-type と %PDF- ヘッダーを検証し、壊れた既存 PDF は再取得する / R14 → npx 直接 spawn ではなく process.execPath + ts-node/register を使う / R15 → npm_config_* と node --require ts-node/register で npm run 引数を安定化する / R16 → AM/AM2 の answers_raw.json と questions_raw.json の qNo・correctOption・選択肢を同期する / R17 → PM/PM1/PM2 は questions_transformed.json と subQuestions 解答欄を同期する / R18 → Mermaid のリンクラベルは -->|label| または ---|label| に正規化し、非ASCIIの円形節点ラベルは引用する / R19 → 新形式午後ヘッダーは CSS Modules を使う / R20 → AIAnswerBox の draftKey・文字数制限を維持する / R21 → 新形式午後の総合スコアは平均を /100、件数は解答欄数で表示する / R22 → section.answer・section.questions・空 subQuestions も解答欄化する / R23 → 日本語 ER 図・subgraph は sanitizeMermaid で描画可能に正規化する / R24 → GitHub Actions の artifact 取得は actions/download-artifact@v6 を使う / R24b → PRの追加修正はpull_request synchronizeでStaging再デプロイし、古い実行をconcurrencyでキャンセルする / R25 → SCPMExamView の解答例解説は ReactMarkdown で描画する / R26 → 解答例ラベルは不透明アンバー背景 + 濃色文字で視認性を保つ / R27 → 子設問を持つ説明だけの親見出しは解答欄化せず、午後データ監査を全区分で実行する / R28 → 午後問題は qNo 完全一致だけで解決し、位置番号フォールバックを再導入しない / R29 → answerChoices を持つ午後小問は radio/checkbox 選択式UIで採点・記録する / R30 → 午後OCRは複数大問PDF向けに JSON array を要求する / R31 → 午後変換はGeminiキーをローテーションする / R32 → 解答OCRは午後記述式の模範解答を抽出する / R33 → 受講者想定E2Eはfixture答案を入力し採点・保存まで検証する / R34 → 午後回答欄IDはresolvePMQuestionBaseIdで生成する / R35 → E2E証跡レポートは今回実行分の画像だけを掲載する / R36 → 午後問題データの英語混入は公式PDFベースの日本語本文へ補正する / R37 → FE公開問題は公開問題・科目A/BとしてExamsへ同期する"
+Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除 / R6 → error を弱点判定から除外 / R7 → 公式小問スコアを優先 / R8 → document-agent が docs/ を更新 / R9 → セッション進捗保存は currentSessionStats を使用 / R10 → Mermaid CODE_BLOCK マーカーを sanitizeMermaid で除去 / R11 → qNo 欠損を 99 にせず同期失敗として扱う / R12 → tracked 設定から接続文字列・API キー実値を除去 / R13 → download.ts で content-type と %PDF- ヘッダーを検証し、壊れた既存 PDF は再取得する / R14 → npx 直接 spawn ではなく process.execPath + ts-node/register を使う / R15 → npm_config_* と node --require ts-node/register で npm run 引数を安定化する / R16 → AM/AM2 の answers_raw.json と questions_raw.json の qNo・correctOption・選択肢を同期する / R17 → PM/PM1/PM2 は questions_transformed.json と subQuestions 解答欄を同期する / R18 → Mermaid のリンクラベルは -->|label| または ---|label| に正規化し、非ASCIIの円形節点ラベルは引用する / R19 → 新形式午後ヘッダーは CSS Modules を使う / R20 → AIAnswerBox の draftKey・文字数制限を維持する / R21 → 新形式午後の総合スコアは平均を /100、件数は解答欄数で表示する / R22 → section.answer・section.questions・空 subQuestions も解答欄化する / R23 → 日本語 ER 図・subgraph は sanitizeMermaid で描画可能に正規化する / R24 → GitHub Actions の artifact 取得は actions/download-artifact@v6 を使う / R24b → PRの追加修正はpull_request synchronizeでStaging再デプロイし、古い実行をconcurrencyでキャンセルする / R25 → SCPMExamView の解答例解説は ReactMarkdown で描画する / R26 → 解答例ラベルは不透明アンバー背景 + 濃色文字で視認性を保つ / R27 → 子設問を持つ説明だけの親見出しは解答欄化せず、午後データ監査を全区分で実行する / R28 → 午後問題は qNo 完全一致だけで解決し、位置番号フォールバックを再導入しない / R29 → answerChoices を持つ午後小問は radio/checkbox 選択式UIで採点・記録する / R30 → 午後OCRは複数大問PDF向けに JSON array を要求する / R31 → 午後変換はGeminiキーをローテーションする / R32 → 解答OCRは午後記述式の模範解答を抽出する / R33 → 受講者想定E2Eはfixture答案を入力し採点・保存まで検証する / R34 → 午後回答欄IDはresolvePMQuestionBaseIdで生成する / R35 → E2E証跡レポートは今回実行分の画像だけを掲載する / R36 → 午後問題データの英語混入は公式PDFベースの日本語本文へ補正する / R37 → FE公開問題は公開問題・科目A/BとしてExamsへ同期する / R38 → App Service 設定に AI_CHAT_FUNCTION_URL を含める / R39 → App Service と AI Function の両方に AI_CHAT_FUNCTION_SECRET を含める"
 
 if ($FailOnFinding) { exit 1 }
 exit 0

--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -222,6 +222,10 @@ jobs:
       #   本番・Staging ともに同一の US リージョン Function App を経由する。
       - name: Configure App Service settings
         run: |
+          if [ -z "${{ secrets.AI_CHAT_FUNCTION_SECRET }}" ]; then
+            echo "::error::AI_CHAT_FUNCTION_SECRET secret is required for signed aiChat proxy calls."
+            exit 1
+          fi
           az webapp config appsettings set \
             --name ${{ env.AZURE_WEBAPP_NAME }} \
             --resource-group rg-pm-exam-dx-prod \
@@ -229,6 +233,7 @@ jobs:
               WEBSITE_RUN_FROM_PACKAGE=1 \
               WEBSITES_PORT=8080 \
               TELEMETRY_CONNECTION_STRING="${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}" \
+              AI_CHAT_FUNCTION_SECRET="${{ secrets.AI_CHAT_FUNCTION_SECRET }}" \
               AI_CHAT_FUNCTION_URL="https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat"
 
       - name: Deploy to Azure Web App
@@ -344,6 +349,10 @@ jobs:
       - name: Configure Staging App Service settings
         if: steps.config-check.outputs.configured == 'true'
         run: |
+          if [ -z "${{ secrets.AI_CHAT_FUNCTION_SECRET }}" ]; then
+            echo "::error::AI_CHAT_FUNCTION_SECRET secret is required for signed aiChat proxy calls."
+            exit 1
+          fi
           az webapp config appsettings set \
             --name "$STAGING_APP_NAME" \
             --resource-group "$STAGING_RG" \
@@ -360,6 +369,7 @@ jobs:
               TELEMETRY_CONNECTION_STRING="${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}" \
               STAGING_BYPASS_TOKEN="${{ secrets.STAGING_BYPASS_TOKEN }}" \
               STAGING_BYPASS_TARGET_GITHUB_ACCOUNT_ID="${{ secrets.STAGING_BYPASS_TARGET_GITHUB_ACCOUNT_ID }}" \
+              AI_CHAT_FUNCTION_SECRET="${{ secrets.AI_CHAT_FUNCTION_SECRET }}" \
               AI_CHAT_FUNCTION_URL="https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat"
 
       - name: Deploy to Staging Web App

--- a/.github/workflows/azure-functions-ai.yml
+++ b/.github/workflows/azure-functions-ai.yml
@@ -77,6 +77,17 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Configure aiChat authentication secret
+        run: |
+          if [ -z "${{ secrets.AI_CHAT_FUNCTION_SECRET }}" ]; then
+            echo "::error::AI_CHAT_FUNCTION_SECRET secret is required for signed aiChat proxy calls."
+            exit 1
+          fi
+          az functionapp config appsettings set \
+            --name ${{ env.AZURE_FUNCTIONAPP_NAME }} \
+            --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+            --settings AI_CHAT_FUNCTION_SECRET="${{ secrets.AI_CHAT_FUNCTION_SECRET }}"
+
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1
         with:

--- a/apps/api-ai/local.settings.json
+++ b/apps/api-ai/local.settings.json
@@ -4,6 +4,7 @@
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME": "node",
         "GEMINI_API_KEY": "",
+        "AI_CHAT_FUNCTION_SECRET": "",
         "COSMOS_DB_CONNECTION": "",
         "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
     }

--- a/apps/api-ai/src/functions/aiChat.ts
+++ b/apps/api-ai/src/functions/aiChat.ts
@@ -1,5 +1,6 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from "@google/generative-ai";
+import { verifyAiChatRequest } from "../security/aiChatAuth";
 
 interface ChatRequest {
     systemPrompt: string;
@@ -30,12 +31,22 @@ export async function aiChat(request: HttpRequest, context: InvocationContext): 
     context.log("AI Chat request received");
 
     try {
+        const verifiedRequest = await verifyAiChatRequest(request, context);
+        if (!verifiedRequest.ok) {
+            return verifiedRequest.response;
+        }
+
         const apiKey = process.env.GEMINI_API_KEY || "";
         if (!apiKey) {
             return { status: 500, jsonBody: { error: "API Key not configured" } };
         }
 
-        const body: ChatRequest = (await request.json()) as ChatRequest;
+        let body: ChatRequest;
+        try {
+            body = JSON.parse(verifiedRequest.rawBody) as ChatRequest;
+        } catch {
+            return { status: 400, jsonBody: { error: "Invalid JSON body" } };
+        }
         const { systemPrompt, userMessage } = body || ({} as ChatRequest);
 
         if (!systemPrompt || !userMessage || typeof systemPrompt !== "string" || typeof userMessage !== "string") {

--- a/apps/api-ai/src/security/aiChatAuth.ts
+++ b/apps/api-ai/src/security/aiChatAuth.ts
@@ -1,0 +1,97 @@
+import { HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const AI_CHAT_TIMESTAMP_HEADER = "x-ai-chat-timestamp";
+export const AI_CHAT_SIGNATURE_HEADER = "x-ai-chat-signature";
+
+const SIGNATURE_PREFIX = "sha256=";
+const MAX_TIMESTAMP_SKEW_SECONDS = 5 * 60;
+
+type AuthResult =
+    | { ok: true; rawBody: string }
+    | { ok: false; response: HttpResponseInit };
+
+function isAzureHostedRuntime(): boolean {
+    return Boolean(process.env.WEBSITE_SITE_NAME || process.env.WEBSITE_INSTANCE_ID);
+}
+
+function getAiChatFunctionSecret(): string {
+    return process.env.AI_CHAT_FUNCTION_SECRET?.trim() || "";
+}
+
+function createExpectedSignature(secret: string, timestamp: string, rawBody: string): string {
+    const digest = createHmac("sha256", secret)
+        .update(`${timestamp}.${rawBody}`)
+        .digest("hex");
+    return `${SIGNATURE_PREFIX}${digest}`;
+}
+
+function safeEqual(left: string, right: string): boolean {
+    const leftBuffer = Buffer.from(left, "utf8");
+    const rightBuffer = Buffer.from(right, "utf8");
+    return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function authFailure(
+    context: InvocationContext,
+    status: 401 | 403 | 500,
+    reason: string,
+): AuthResult {
+    const logMessage = `AI chat authorization failed: ${reason}`;
+    if (status === 500) {
+        context.error(logMessage);
+    } else {
+        context.warn(logMessage);
+    }
+
+    return {
+        ok: false,
+        response: {
+            status,
+            jsonBody: {
+                error: status === 500 ? "AI chat authentication is not configured" : "Unauthorized",
+            },
+        },
+    };
+}
+
+export async function verifyAiChatRequest(
+    request: HttpRequest,
+    context: InvocationContext,
+): Promise<AuthResult> {
+    const rawBody = await request.text();
+    const secret = getAiChatFunctionSecret();
+
+    if (!secret) {
+        if (isAzureHostedRuntime()) {
+            return authFailure(context, 500, "AI_CHAT_FUNCTION_SECRET is missing in Azure runtime");
+        }
+
+        context.warn("AI_CHAT_FUNCTION_SECRET is not configured; allowing unsigned local aiChat request");
+        return { ok: true, rawBody };
+    }
+
+    const timestamp = request.headers.get(AI_CHAT_TIMESTAMP_HEADER);
+    const signature = request.headers.get(AI_CHAT_SIGNATURE_HEADER);
+
+    if (!timestamp || !signature) {
+        return authFailure(context, 401, "missing signature headers");
+    }
+
+    if (!signature.startsWith(SIGNATURE_PREFIX)) {
+        return authFailure(context, 403, "invalid signature format");
+    }
+
+    const timestampNumber = Number(timestamp);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (!Number.isFinite(timestampNumber) || Math.abs(nowSeconds - timestampNumber) > MAX_TIMESTAMP_SKEW_SECONDS) {
+        return authFailure(context, 403, "stale or invalid timestamp");
+    }
+
+    const expected = createExpectedSignature(secret, timestamp, rawBody);
+    if (!safeEqual(signature, expected)) {
+        return authFailure(context, 403, "signature mismatch");
+    }
+
+    return { ok: true, rawBody };
+}

--- a/apps/web/__tests__/api/score.test.ts
+++ b/apps/web/__tests__/api/score.test.ts
@@ -10,6 +10,7 @@ describe('/api/score', () => {
         process.env = { ...originalEnv };
         // 環境依存を排除: AI_CHAT_FUNCTION_URL は各テストで明示的に設定する
         delete process.env.AI_CHAT_FUNCTION_URL;
+        delete process.env.AI_CHAT_FUNCTION_SECRET;
     });
 
     afterEach(() => {
@@ -186,6 +187,7 @@ describe('/api/score', () => {
 
         it('AI_CHAT_FUNCTION_URL 経由でのプロキシ採点が実行できる', async () => {
             process.env.AI_CHAT_FUNCTION_URL = 'https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat';
+            process.env.AI_CHAT_FUNCTION_SECRET = 'test-shared-secret';
             delete process.env.GEMINI_API_KEY;
 
             const mockResponse = {
@@ -202,10 +204,11 @@ describe('/api/score', () => {
             };
 
             // fetch をモック（US Function App へのリクエスト）
-            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            const fetchMock = vi.fn().mockResolvedValue({
                 ok: true,
                 json: async () => ({ text: JSON.stringify(mockResponse) }),
-            }));
+            });
+            vi.stubGlobal('fetch', fetchMock);
 
             const { POST } = await import('@/app/api/score/route');
             const request = new NextRequest('http://localhost:3000/api/score', {
@@ -222,12 +225,50 @@ describe('/api/score', () => {
 
             expect(response.status).toBe(200);
             expect(data.score).toBe(80);
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const [, init] = fetchMock.mock.calls[0];
+            expect(init.headers).toMatchObject({
+                'Content-Type': 'application/json',
+                'x-ai-chat-timestamp': expect.any(String),
+                'x-ai-chat-signature': expect.stringMatching(/^sha256=[a-f0-9]{64}$/),
+            });
 
+            vi.unstubAllGlobals();
+        });
+
+        it('AI_CHAT_FUNCTION_SECRET 未設定でプロキシ採点を拒否する', async () => {
+            process.env.AI_CHAT_FUNCTION_URL = 'https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat';
+            delete process.env.AI_CHAT_FUNCTION_SECRET;
+            delete process.env.GEMINI_API_KEY;
+
+            const fetchMock = vi.fn();
+            vi.stubGlobal('fetch', fetchMock);
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const { POST } = await import('@/app/api/score/route');
+            const request = new NextRequest('http://localhost:3000/api/score', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    question: 'テスト問題',
+                    userAnswer: 'テスト回答',
+                }),
+            });
+
+            const response = await POST(request);
+            const data = await response.json();
+
+            expect(response.status).toBe(503);
+            expect(data.error).toBe('AI proxy authentication is not configured');
+            expect(fetchMock).not.toHaveBeenCalled();
+
+            consoleError.mockRestore();
             vi.unstubAllGlobals();
         });
 
         it('AI_CHAT_FUNCTION_URL プロキシがエラーを返した場合は500を返す', async () => {
             process.env.AI_CHAT_FUNCTION_URL = 'https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat';
+            process.env.AI_CHAT_FUNCTION_SECRET = 'test-shared-secret';
             delete process.env.GEMINI_API_KEY;
 
             vi.stubGlobal('fetch', vi.fn().mockResolvedValue({

--- a/apps/web/__tests__/lib/ai-chat-auth.test.ts
+++ b/apps/web/__tests__/lib/ai-chat-auth.test.ts
@@ -1,0 +1,53 @@
+import { createHmac } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  AI_CHAT_SIGNATURE_HEADER,
+  AI_CHAT_TIMESTAMP_HEADER,
+  createAiChatAuthHeaders,
+  createAiChatSignature,
+} from '@/lib/ai-chat-auth';
+
+describe('ai-chat-auth', () => {
+  const originalSecret = process.env.AI_CHAT_FUNCTION_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.AI_CHAT_FUNCTION_SECRET;
+    } else {
+      process.env.AI_CHAT_FUNCTION_SECRET = originalSecret;
+    }
+  });
+
+  it('リクエスト本文とタイムスタンプからHMAC署名を生成する', () => {
+    process.env.AI_CHAT_FUNCTION_SECRET = 'unit-test-secret';
+    const rawBody = JSON.stringify({ systemPrompt: 's', userMessage: 'u' });
+    const timestamp = '1789200000';
+
+    const result = createAiChatSignature(rawBody, timestamp);
+    const expectedDigest = createHmac('sha256', 'unit-test-secret')
+      .update(`${timestamp}.${rawBody}`)
+      .digest('hex');
+
+    expect(result).toEqual({
+      timestamp,
+      signature: `sha256=${expectedDigest}`,
+    });
+  });
+
+  it('署名ヘッダーを生成する', () => {
+    process.env.AI_CHAT_FUNCTION_SECRET = 'unit-test-secret';
+    const headers = createAiChatAuthHeaders('{"ok":true}');
+
+    expect(headers[AI_CHAT_TIMESTAMP_HEADER]).toEqual(expect.any(String));
+    expect(headers[AI_CHAT_SIGNATURE_HEADER]).toMatch(/^sha256=[a-f0-9]{64}$/);
+  });
+
+  it('シークレット未設定時は例外を投げる', () => {
+    delete process.env.AI_CHAT_FUNCTION_SECRET;
+
+    expect(() => createAiChatSignature('{}', '1789200000')).toThrow(
+      'AI_CHAT_FUNCTION_SECRET is not configured',
+    );
+  });
+});

--- a/apps/web/app/api/score/route.ts
+++ b/apps/web/app/api/score/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { createAiChatAuthHeaders } from '@/lib/ai-chat-auth';
 
 export const runtime = 'nodejs';
 
@@ -65,10 +66,19 @@ export async function POST(req: NextRequest) {
 
         if (aiChatFunctionUrl) {
             // 本番: US Azure Function 経由（East Asia から Gemini への地域制限を回避）
+            const requestBody = JSON.stringify({ systemPrompt: SYSTEM_PROMPT, userMessage: prompt });
+            let authHeaders: Record<string, string>;
+            try {
+                authHeaders = createAiChatAuthHeaders(requestBody);
+            } catch (error) {
+                console.error('AI_CHAT_FUNCTION_SECRET is not set for AI proxy request');
+                return NextResponse.json({ error: 'AI proxy authentication is not configured' }, { status: 503 });
+            }
+
             const res = await fetch(aiChatFunctionUrl, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ systemPrompt: SYSTEM_PROMPT, userMessage: prompt }),
+                headers: { 'Content-Type': 'application/json', ...authHeaders },
+                body: requestBody,
             });
             if (!res.ok) {
                 throw new Error(`AI proxy failed: ${res.status} ${await res.text().catch(() => '')}`);

--- a/apps/web/lib/ai-assistant/gemini-chat.ts
+++ b/apps/web/lib/ai-assistant/gemini-chat.ts
@@ -1,4 +1,5 @@
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import { createAiChatAuthHeaders } from '@/lib/ai-chat-auth';
 
 const apiKey = process.env.GEMINI_API_KEY;
 
@@ -61,10 +62,11 @@ async function* proxyChatResponse(
     systemPrompt: string,
     userMessage: string,
 ): AsyncGenerator<string> {
+    const requestBody = JSON.stringify({ systemPrompt, userMessage });
     const response = await fetch(AI_CHAT_FUNCTION_URL as string, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ systemPrompt, userMessage }),
+        headers: { 'Content-Type': 'application/json', ...createAiChatAuthHeaders(requestBody) },
+        body: requestBody,
     });
 
     if (!response.ok) {

--- a/apps/web/lib/ai-chat-auth.ts
+++ b/apps/web/lib/ai-chat-auth.ts
@@ -1,0 +1,35 @@
+import { createHmac } from 'node:crypto';
+
+export const AI_CHAT_TIMESTAMP_HEADER = 'x-ai-chat-timestamp';
+export const AI_CHAT_SIGNATURE_HEADER = 'x-ai-chat-signature';
+
+function getAiChatFunctionSecret(): string {
+  return process.env.AI_CHAT_FUNCTION_SECRET?.trim() || '';
+}
+
+export function createAiChatSignature(
+  rawBody: string,
+  timestampSeconds = Math.floor(Date.now() / 1000).toString(),
+): { timestamp: string; signature: string } {
+  const secret = getAiChatFunctionSecret();
+  if (!secret) {
+    throw new Error('AI_CHAT_FUNCTION_SECRET is not configured');
+  }
+
+  const digest = createHmac('sha256', secret)
+    .update(`${timestampSeconds}.${rawBody}`)
+    .digest('hex');
+
+  return {
+    timestamp: timestampSeconds,
+    signature: `sha256=${digest}`,
+  };
+}
+
+export function createAiChatAuthHeaders(rawBody: string): Record<string, string> {
+  const { timestamp, signature } = createAiChatSignature(rawBody);
+  return {
+    [AI_CHAT_TIMESTAMP_HEADER]: timestamp,
+    [AI_CHAT_SIGNATURE_HEADER]: signature,
+  };
+}

--- a/apps/web/lib/scoring/llmClient.ts
+++ b/apps/web/lib/scoring/llmClient.ts
@@ -9,6 +9,7 @@
  */
 
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { createAiChatAuthHeaders } from '@/lib/ai-chat-auth';
 
 const AI_CHAT_FUNCTION_URL = process.env.AI_CHAT_FUNCTION_URL;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
@@ -28,10 +29,11 @@ export interface PerspectiveLlmRawResult {
 export async function callPerspectiveLlmDefault(prompt: string): Promise<PerspectiveLlmRawResult> {
   let text: string;
   if (AI_CHAT_FUNCTION_URL) {
+    const requestBody = JSON.stringify({ systemPrompt: SYSTEM_PROMPT_DEFAULT, userMessage: prompt });
     const res = await fetch(AI_CHAT_FUNCTION_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ systemPrompt: SYSTEM_PROMPT_DEFAULT, userMessage: prompt }),
+      headers: { 'Content-Type': 'application/json', ...createAiChatAuthHeaders(requestBody) },
+      body: requestBody,
     });
     if (!res.ok) throw new Error(`LLM proxy failed: ${res.status} ${await res.text().catch(() => '')}`);
     const data = (await res.json()) as { text?: string; error?: string };

--- a/docs/01_planning/azure_config/03_AzureFunctions.md
+++ b/docs/01_planning/azure_config/03_AzureFunctions.md
@@ -85,6 +85,7 @@ Next.js の API Routes (`/app/api/**`) は自動的に Managed Functions とし�
 | 関数名   | トリガー    | ルート       | 用途                     |
 | :------- | :---------- | :----------- | :----------------------- |
 | `aiPlan` | HTTP (POST) | `/api/ai/plan` | AI学習プラン生成         |
+| `aiChat` | HTTP (POST) | `/api/ai/chat` | 採点・AIアシスタント向け Gemini プロキシ |
 
 ### 3.5 使用モデル
 
@@ -100,9 +101,12 @@ Next.js の API Routes (`/app/api/**`) は自動的に Managed Functions とし�
 | キー                   | 設定値・参照先                        | 用途                       |
 | :--------------------- | :------------------------------------ | :------------------------- |
 | `GEMINI_API_KEY`       | Google AI Studio APIキー              | Gemini API認証             |
+| `AI_CHAT_FUNCTION_SECRET` | Web App と共有する HMAC シークレット | `aiChat` 署名検証          |
 | `COSMOS_DB_CONNECTION` | CosmosDB接続文字列                    | メトリクス保存用           |
 | `FUNCTIONS_WORKER_RUNTIME` | `node`                            | ランタイム指定             |
 | `FUNCTIONS_EXTENSION_VERSION` | `~4`                           | Functions V4               |
+
+`aiChat` は `x-ai-chat-timestamp` と `x-ai-chat-signature` を検証し、Gemini API 呼び出し前に未署名・不正署名のリクエストを拒否する。Azure 実行環境で `AI_CHAT_FUNCTION_SECRET` が未設定の場合は fail closed とし、500 を返す。ローカル Function 実行では同変数が未設定の場合に限り警告ログ付きで unsigned request を許可する。
 
 ### 3.7 デプロイ手順
 
@@ -119,6 +123,8 @@ func azure functionapp publish func-pm-exam-dx-ai-us --build remote
 Functions in func-pm-exam-dx-ai-us:
     aiPlan - [httpTrigger]
         Invoke url: https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/plan
+  aiChat - [httpTrigger]
+    Invoke url: https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat
 ```
 
 ### 3.8 トラブルシューティング

--- a/docs/02_design/01_ConfigurationDesign.md
+++ b/docs/02_design/01_ConfigurationDesign.md
@@ -130,6 +130,8 @@ NEXTAUTH_SECRET=<secret>
 GOOGLE_ID=<oauth_client_id>
 GOOGLE_SECRET=<oauth_client_secret>
 AZURE_COSMOS_CONNECTION_STRING=<cosmos_connection>
+AI_CHAT_FUNCTION_URL=<local_or_azure_ai_chat_url>
+AI_CHAT_FUNCTION_SECRET=<shared_hmac_secret_for_ai_chat>
 ```
 
 #### API Functions
@@ -146,8 +148,11 @@ COSMOS_DB_CONNECTION=<cosmos_connection>
 AzureWebJobsStorage=UseDevelopmentStorage=true
 FUNCTIONS_WORKER_RUNTIME=node
 GEMINI_API_KEY=<google_ai_api_key>
+AI_CHAT_FUNCTION_SECRET=<shared_hmac_secret_for_ai_chat>
 COSMOS_DB_CONNECTION=<cosmos_connection>
 ```
+
+`AI_CHAT_FUNCTION_SECRET` は Web App と AI Functions の双方に同一値を設定する。Web 側は `aiChat` 呼び出し時に `x-ai-chat-timestamp` と `x-ai-chat-signature` を生成し、AI Functions 側は Gemini API 呼び出し前に検証する。ローカル開発では `AI_CHAT_FUNCTION_URL` 未設定なら従来どおり `GEMINI_API_KEY` 直接呼び出しを使う。ローカル Function を経由する場合は Web と Function の両方に同じ `AI_CHAT_FUNCTION_SECRET` を設定する。
 
 ### 4.2 ビルド設定
 
@@ -210,6 +215,8 @@ read / edit / search / execute / agent / web / todo
 - **2026-05-02**: tracked 設定ファイルの secret material 禁止方針を追加
   - `local.settings.json` / `.env.template` は空値またはプレースホルダーのみとし、実値は未追跡環境から注入する方針を明記
   - `self-inspect` R12 による tracked 設定ファイルの secret material 検出を追記
+- **2026-05-14**: `aiChat` HMAC 署名用の `AI_CHAT_FUNCTION_SECRET` を追加
+  - Web App と AI Function App の双方で同一シークレットを使用し、署名付きプロキシ呼び出しだけを許可する方針を明記
 - **2026-04-30**: GitHub Actions の日本語フィールド同期 workflow 設計を追記
   - `PROJECT_PAT` 未提供時は同期をスキップし、PR の品質ゲートをブロックしない方針を明記
 - **2026-04-29**: Copilot Agent カスタマイズ設定セクションを追加

--- a/docs/02_design/06_DeploymentDesign.md
+++ b/docs/02_design/06_DeploymentDesign.md
@@ -107,6 +107,7 @@ PR の `pull_request` トリガーは `opened` / `synchronize` / `reopened` / `r
 | `AUTH_GITHUB_SECRET` | GitHub OAuth シークレット | 本番・Staging共通 |
 | `AUTH_GOOGLE_ID` | Google OAuth クライアントID | 本番・Staging共通 |
 | `AUTH_GOOGLE_SECRET` | Google OAuth シークレット | 本番・Staging共通 |
+| `AI_CHAT_FUNCTION_SECRET` | `aiChat` HMAC 署名用共有シークレット | 本番・Staging・AI Function共通 |
 | `AZURE_STAGING_WEBAPP_NAME` | `app-pm-exam-dx-staging` | **Staging専用** |
 | `COSMOS_DB_CONNECTION_STAGING` | Staging CosmosDB接続文字列 | **Staging専用** |
 | `NEXTAUTH_SECRET_STAGING` | Staging用 NextAuth シークレット | **Staging専用** |
@@ -154,6 +155,8 @@ App Service の環境変数は **GitHub Actions ワークフロー内で `az web
 | `AUTH_GOOGLE_SECRET` | Google OAuth | App Service 設定（ポータル）|
 | `TELEMETRY_CONNECTION_STRING` | App Insights（IPAコードレス回避用名）| CI/CD |
 | `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Google Analytics 4 | App Service 設定（ポータル）|
+| `AI_CHAT_FUNCTION_URL` | US East 2 の `aiChat` エンドポイント | CI/CD |
+| `AI_CHAT_FUNCTION_SECRET` | `aiChat` 呼び出し署名用共有シークレット | GitHub Secret から CI/CD で設定 |
 
 > **IPA コードレスエージェント無効化**: Linux App Service の IPA は `APPLICATIONINSIGHTS_*` / `APPINSIGHTS_*` プレフィックスや `*_EXTENSION_VERSION` 設定の存在を検出して自動有効化する。手動 SDK の OpenTelemetry セットアップと競合するため、CI/CD デプロイ時に完全削除し `TELEMETRY_CONNECTION_STRING` という独自名で渡す。
 
@@ -167,6 +170,7 @@ Staging 固有の設定はワークフローの `deploy-staging` ジョブで自
 | `AZURE_STAGING_WEBAPP_NAME` | `app-pm-exam-dx-staging` |
 | `COSMOS_DB_CONNECTION_STAGING` | pm-exam-dx-staging-db の接続文字列 |
 | `NEXTAUTH_SECRET_STAGING` | `openssl rand -base64 32` で生成 |
+| `AI_CHAT_FUNCTION_SECRET` | Web App と AI Function App で共有する `aiChat` HMAC 署名用シークレット |
 
 ## 6. トラブルシューティング
 
@@ -234,6 +238,9 @@ export async function GET(req: NextRequest) {
 
 | 日付 | 変更内容 | 担当 |
 |------|---------|------|
+| 2026/05/14 | **aiChat 署名認証設定の追加** | エージェント |
+| | - `AI_CHAT_FUNCTION_SECRET` を GitHub Secrets / App Service / AI Function App の必須設定として追加 | |
+| | - 未署名・不正署名リクエストを Gemini API 到達前に拒否する運用を追記 | |
 | 2026/05/07 | **GitHub Actions artifact 取得方式の修正** | エージェント |
 | | - `gh run download` を `actions/download-artifact@v6` に置換 | |
 | | - checkout 不在ジョブでの `fatal: not a git repository` 再発防止を明記 | |
@@ -400,7 +407,10 @@ Azure Portal > Function Apps > `func-pm-exam-dx-ai-us` > 設定 > 環境変数
 | 変数名 | 用途 | 必須 |
 |--------|------|------|
 | `GEMINI_API_KEY` | Google AI Studio APIキー | ✅ |
+| `AI_CHAT_FUNCTION_SECRET` | `aiChat` HMAC 署名検証用。Web App 側と同一値 | ✅ |
 | `COSMOS_DB_CONNECTION` | CosmosDB接続文字列（メトリクス用） | ✅ |
+
+`AI_CHAT_FUNCTION_SECRET` は GitHub Actions Secret と Azure Function App / App Service の App Settings に同一値を設定する。`aiChat` は `x-ai-chat-timestamp` と `x-ai-chat-signature` を検証し、ヘッダー欠落は 401、不正署名や期限切れは 403 で拒否する。未認証リクエストは Gemini API へ到達しない。
 
 ## 10. 参考資料
 

--- a/docs/02_design/14_PMPracticeAndScoringDesign.md
+++ b/docs/02_design/14_PMPracticeAndScoringDesign.md
@@ -4,6 +4,7 @@
 
 | 日付 | 変更内容 |
 |------|------|
+| 2026-05-14 | `aiChat` 呼び出しを `AI_CHAT_FUNCTION_SECRET` による HMAC 署名付きリクエストへ変更し、未署名・不正署名を Gemini API 到達前に拒否する仕様を追加。 |
 | 2026-05-10 | `/api/score` が Azure App Service 上で `AI_CHAT_FUNCTION_URL` 未設定のまま Gemini 直接呼び出しへフォールバックしないよう、503 の設定エラーとして返す仕様に変更。本番ワークフローにも `AI_CHAT_FUNCTION_URL` を追加し、US Function (`aiChat`) の長文採点プロンプト上限を 32,000 文字へ拡張。 |
 | 2026-05-09 | `/api/score` Gemini 直接呼び出しフォールバック（ローカル開発用）に `systemInstruction: SYSTEM_PROMPT` を追加し、プロキシ経由と採点品質を統一。`export const runtime = 'nodejs'` を追加し Edge Runtime での誤動作リスクを解消。テストの `beforeEach` で `AI_CHAT_FUNCTION_URL` を必ず削除して環境依存を排除。 |
 | 2026-05-09 | `/api/score` が East Asia から Gemini API を直接呼び出せない地域制限バグを修正。`AI_CHAT_FUNCTION_URL` が設定されている場合は US リージョンの Azure Function (`aiChat`) を経由するプロキシ方式に変更。ローカル開発は従来通り直接呼び出し。 |
@@ -138,7 +139,8 @@ sequenceDiagram
     User->>Box: 回答を入力し採点を実行
     Box->>API: question / userAnswer / modelAnswer を送信
     alt AI_CHAT_FUNCTION_URL が設定済み（本番・Staging）
-        API->>Func: systemPrompt / userMessage を送信
+        API->>Func: 署名付き systemPrompt / userMessage を送信
+        Func->>Func: HMAC 署名・タイムスタンプ検証
         Func->>Gemini: CLKS プロンプトを送信
         Gemini-->>Func: テキスト（JSON）を返却
         Func-->>API: { text } を返却
@@ -203,11 +205,14 @@ sequenceDiagram
 | 変数名 | 必須 | 用途 | 備考 |
 |------|------|------|------|
 | `AI_CHAT_FUNCTION_URL` | **本番・Staging 必須** | `/api/score` → US Azure Function プロキシ | 未設定時は `GEMINI_API_KEY` 直接呼び出し（ローカル開発用フォールバック）。East Asia から Gemini を直接呼ぶと地域制限エラーになるため、本番では必須。例: `https://func-pm-exam-dx-ai-us.azurewebsites.net/api/ai/chat` |
+| `AI_CHAT_FUNCTION_SECRET` | **本番・Staging 必須** | `aiChat` 署名付きプロキシ呼び出し | Web App と AI Function App に同一値を設定する。`x-ai-chat-timestamp` と `x-ai-chat-signature` の HMAC-SHA256 検証に使用 |
 | `GEMINI_API_KEY` | ローカル開発のみ必須 | `AI_CHAT_FUNCTION_URL` 未設定時のフォールバック | Azure App Service 上では使用しない。未設定かつ `AI_CHAT_FUNCTION_URL` も未設定の場合は 500、Azure 上で `AI_CHAT_FUNCTION_URL` が未設定の場合は 503 を返す |
 | `COSMOS_DB_CONNECTION` | サーバー運用上必須 | 採点結果の保存・セッション更新 | 未設定時は DB 保存を無効化 |
 | `NEXT_PUBLIC_API_BASE` | 任意 | クライアント API 呼び出し | 未設定時は `/api` |
 
 > **East Asia 地域制限について**: Azure App Service (East Asia) から Gemini API を直接呼び出すと `User location is not supported` エラーになる。すべての Gemini 呼び出しは US East 2 リージョンの Azure Function App (`aiChat`) を経由させること。`AI_CHAT_FUNCTION_URL` が未設定の場合のみ Gemini 直接呼び出しにフォールバックする（ローカル開発専用）。`aiChat` は午後問題本文を含む採点プロンプトを受けられるよう、`userMessage` 最大 32,000 文字まで許容する。
+
+> **aiChat 署名認証について**: `AI_CHAT_FUNCTION_URL` を使う経路は `AI_CHAT_FUNCTION_SECRET` で `<timestamp>.<rawBody>` に HMAC-SHA256 署名を付与する。Function 側はヘッダー欠落を 401、不正署名・期限切れを 403 として拒否し、Gemini API には到達させない。ローカル開発では `AI_CHAT_FUNCTION_URL` を未設定にして直接 Gemini を呼ぶか、Web とローカル Function に同一の `AI_CHAT_FUNCTION_SECRET` を設定してプロキシ経路を検証する。
 
 ---
 

--- a/docs/02_design/15_CommonApiAndErrorDesign.md
+++ b/docs/02_design/15_CommonApiAndErrorDesign.md
@@ -115,6 +115,7 @@ sequenceDiagram
 | `COSMOS_DB_CONNECTION` | サーバー運用上必須 | 全 CosmosDB API の接続先 | 未設定時は DB 無効化 |
 | `NEXTAUTH_SECRET` / `AUTH_SECRET` | 認証 API で必要 | セッション署名 | NextAuth 設定 |
 | `AI_CHAT_FUNCTION_URL` | 本番・Staging 必須 | `/api/score` と AI 採点 API の US Function プロキシ | Azure App Service 上で未設定の場合、`/api/score` は 503 を返す |
+| `AI_CHAT_FUNCTION_SECRET` | 本番・Staging 必須 | `aiChat` への HMAC 署名生成・検証 | Web App と AI Function App の両方に同一値を設定する。未設定時は Azure 上で処理を拒否する |
 | `GEMINI_API_KEY` | ローカル開発のみ必須 | `AI_CHAT_FUNCTION_URL` 未設定時の直接呼び出し | Azure App Service 上では直接呼び出しへフォールバックしない |
 | `NEXT_PUBLIC_APPLICATIONINSIGHTS_CONNECTION_STRING` | 任意 | クライアント計測初期化 | 公開値として扱う |
 | `TELEMETRY_CONNECTION_STRING` | 任意 | Node 側計測 | Managed Identity と併用。ブラウザには返さない |
@@ -225,7 +226,18 @@ sequenceDiagram
 - `/api/session/create`
 - `/api/learning-records POST`
 
-### 12.3 認可上の不整合
+### 12.3 aiChat 内部プロキシ認証
+
+`/api/score`、午後採点 v2、AI アシスタントが US East 2 の `aiChat` を呼び出す場合は、`AI_CHAT_FUNCTION_SECRET` でリクエスト本文と Unix 秒タイムスタンプに HMAC-SHA256 署名を付与する。
+
+| ヘッダー | 内容 |
+|------|------|
+| `x-ai-chat-timestamp` | 署名対象に含める Unix 秒。Function 側で 5 分以内の時刻だけ受け付ける |
+| `x-ai-chat-signature` | `sha256=<hex>` 形式。署名対象は `<timestamp>.<rawBody>` |
+
+AI Function App 側は Gemini API キー確認や Gemini 呼び出しより前に署名を検証する。ヘッダー欠落は 401、不正署名・期限切れは 403、Azure 実行環境で `AI_CHAT_FUNCTION_SECRET` が未設定の場合は 500 を返し、いずれも Gemini API へ到達させない。ローカル Function 実行では `AI_CHAT_FUNCTION_SECRET` 未設定時のみ警告ログを出して unsigned request を許可し、ローカル検証を阻害しない。
+
+### 12.4 認可上の不整合
 
 - 一部の読込 API は厳格だが、書込 API は body の `userId` を信頼している
 - セッション作成と記録保存で認可方針が揃っていない
@@ -260,6 +272,7 @@ sequenceDiagram
 共通 API の観測点は以下である。
 
 - Route Handler 内の `console.error`
+- `aiChat` の署名検証失敗ログ (`AI chat authorization failed: ...`)
 - `track POST` による PageViews 保存
 - Application Insights 設定の読込
 
@@ -272,6 +285,7 @@ sequenceDiagram
 | 種別 | 観点 |
 |------|------|
 | API | 主要 Route Handler が 400 / 401 / 404 / 500 を返し分けること |
+| Security | `aiChat` が署名ヘッダー欠落を 401、不正署名を 403 とし、Gemini 呼び出し前に拒否すること |
 | Unit | `lib/api.ts` がエラー時に関数ごとの期待値を返すこと |
 | Integration | `session PATCH` が owner 以外を拒否すること |
 | Integration | `learning-records GET` が query の `userId` を無視すること |


### PR DESCRIPTION
## 概要
- Issue #265 対応として、Web から AI Function `aiChat` へ送るリクエストに HMAC-SHA256 署名を追加
- Function 側で `x-ai-chat-timestamp` / `x-ai-chat-signature` を検証し、不正リクエストを Gemini API 呼び出し前に拒否
- App Service / Function App のデプロイ設定、self-inspect R39、設計書を同期更新

Fixes #265

## 実装メモ
- 共有シークレットは `AI_CHAT_FUNCTION_SECRET` として GitHub Actions Secret / Azure App Settings で管理
- ローカル Function 実行では未設定時のみ unsigned request を許可し、Azure 実行環境では未設定を 500 として扱う
- Web 側の既知 aiChat 呼び出し元（`/api/score`、午後採点 v2、AI アシスタント）を署名付き送信へ統一

## テスト
- `npm run test:run -- __tests__/api/score.test.ts __tests__/lib/ai-chat-auth.test.ts` ✅ 19 passed
- `cd apps/api-ai && npm run build` ✅
- `npm run test:unit` ✅ 64 files / 699 tests passed
- `pwsh .github/hooks/self-inspect.ps1 -Mode start` ✅ R1-R39 passed
- `npm run build` ✅

## E2E テストエビデンス報告書

UI 変更を含まないため、E2E テストは未実行です。