### PR TITLE
feat: 午後データ品質監査をCI必須化

### DIFF
--- a/.github/hooks/self-inspect.ps1
+++ b/.github/hooks/self-inspect.ps1
@@ -1257,8 +1257,8 @@ if (Test-Path $cosmosWebClient) {
 }
 
 # ---------------------------------------------------------------------------
-# R42: Web unit test は少数ファイルのバッチ実行を経由すること
-#      (単一の vitest run で全ファイルを投入すると worker 起動タイムアウトが発生しやすい)
+# R42: Web unit test は happy-dom + 少数ファイルのバッチ実行を経由すること
+#      (jsdom は devcontainer で worker 起動 timeout を誘発しやすい)
 # ---------------------------------------------------------------------------
 $webPackageJson = Join-Path $WebRoot 'package.json'
 $webVitestConfig = Join-Path $WebRoot 'vitest.config.ts'
@@ -1271,6 +1271,11 @@ if (Test-Path $webPackageJson) {
             -File $webPackageJson `
             -Detail 'apps/web の test:run は worker 起動タイムアウトを避けるため scripts/run-vitest-batches.mjs 経由で実行してください'
     }
+    if ($raw -notmatch '"happy-dom"\s*:\s*"\^[^" ]+"') {
+        Add-Finding -Rule 'R42-vitest-batched-unit-runner' -Severity 'Medium' `
+            -File $webPackageJson `
+            -Detail 'Vitest の DOM 環境は jsdom ではなく軽量な happy-dom を devDependency として固定してください'
+    }
 }
 if (-not (Test-Path $webVitestBatchRunner)) {
     Add-Finding -Rule 'R42-vitest-batched-unit-runner' -Severity 'Medium' `
@@ -1279,10 +1284,10 @@ if (-not (Test-Path $webVitestBatchRunner)) {
 }
 if (Test-Path $webVitestConfig) {
     $raw = Get-Content -LiteralPath $webVitestConfig -Raw
-    if ($raw -notmatch "pool:\s*'threads'" -or $raw -notmatch 'maxWorkers:\s*4') {
+    if ($raw -notmatch "environment:\s*'happy-dom'" -or $raw -notmatch "pool:\s*'threads'" -or $raw -notmatch 'maxWorkers:\s*4') {
         Add-Finding -Rule 'R42-vitest-batched-unit-runner' -Severity 'Medium' `
             -File $webVitestConfig `
-            -Detail 'vitest.config.ts は pool: threads と maxWorkers: 4 を維持し、devcontainer / pre-push の worker 起動を安定化してください'
+            -Detail 'vitest.config.ts は environment: happy-dom、pool: threads、maxWorkers: 4 を維持し、devcontainer / pre-push の worker 起動を安定化してください'
     }
 }
 
@@ -1306,7 +1311,7 @@ foreach ($f in $findings) {
 }
 
 Write-Host ""
-Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除 / R6 → error を弱点判定から除外 / R7 → 公式小問スコアを優先 / R8 → document-agent が docs/ を更新 / R9 → セッション進捗保存は currentSessionStats を使用 / R10 → Mermaid CODE_BLOCK マーカーを sanitizeMermaid で除去 / R11 → qNo 欠損を 99 にせず同期失敗として扱う / R12 → tracked 設定から接続文字列・API キー実値を除去 / R13 → download.ts で content-type と %PDF- ヘッダーを検証し、壊れた既存 PDF は再取得する / R14 → npx 直接 spawn ではなく process.execPath + ts-node/register を使う / R15 → npm_config_* と node --require ts-node/register で npm run 引数を安定化する / R16 → AM/AM2 の answers_raw.json と questions_raw.json の qNo・correctOption・選択肢を同期する / R17 → PM/PM1/PM2 は questions_transformed.json と subQuestions 解答欄を同期する / R18 → Mermaid のリンクラベルは -->|label| または ---|label| に正規化し、非ASCIIの円形節点ラベルは引用する / R19 → 新形式午後ヘッダーは CSS Modules を使う / R20 → AIAnswerBox の draftKey・文字数制限を維持する / R21 → 新形式午後の総合スコアは平均を /100、件数は解答欄数で表示する / R22 → section.answer・section.questions・空 subQuestions も解答欄化する / R23 → 日本語 ER 図・subgraph は sanitizeMermaid で描画可能に正規化する / R24 → GitHub Actions の artifact 取得は actions/download-artifact@v6 を使う / R24b → PRの追加修正はpull_request synchronizeでStaging再デプロイし、古い実行をconcurrencyでキャンセルする / R25 → SCPMExamView の解答例解説は ReactMarkdown で描画する / R26 → 解答例ラベルは不透明アンバー背景 + 濃色文字で視認性を保つ / R27 → 子設問を持つ説明だけの親見出しは解答欄化せず、午後データ監査を全区分で実行する / R28 → 午後問題は qNo 完全一致だけで解決し、位置番号フォールバックを再導入しない / R29 → answerChoices を持つ午後小問は radio/checkbox 選択式UIで採点・記録する / R30 → 午後OCRは複数大問PDF向けに JSON array を要求する / R31 → 午後変換はGeminiキーをローテーションする / R32 → 解答OCRは午後記述式の模範解答を抽出する / R33 → 受講者想定E2Eはfixture答案を入力し採点・保存まで検証する / R34 → 午後回答欄IDはresolvePMQuestionBaseIdで生成する / R35 → E2E証跡レポートは今回実行分の画像だけを掲載する / R36 → 午後問題データの英語混入は公式PDFベースの日本語本文へ補正する / R37 → FE公開問題は公開問題・科目A/BとしてExamsへ同期する / R38 → App Service 設定に AI_CHAT_FUNCTION_URL を含める / R39 → App Service と AI Function の両方に AI_CHAT_FUNCTION_SECRET を含める / R40 → devcontainer からの Cosmos Emulator は host.docker.internal もローカル接続として扱う / R41 → Web 側 CosmosClient は接続文字列確認後に動的 import する / R42 → Web unit test は scripts/run-vitest-batches.mjs 経由で少数ファイルずつ実行する"
+Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除 / R6 → error を弱点判定から除外 / R7 → 公式小問スコアを優先 / R8 → document-agent が docs/ を更新 / R9 → セッション進捗保存は currentSessionStats を使用 / R10 → Mermaid CODE_BLOCK マーカーを sanitizeMermaid で除去 / R11 → qNo 欠損を 99 にせず同期失敗として扱う / R12 → tracked 設定から接続文字列・API キー実値を除去 / R13 → download.ts で content-type と %PDF- ヘッダーを検証し、壊れた既存 PDF は再取得する / R14 → npx 直接 spawn ではなく process.execPath + ts-node/register を使う / R15 → npm_config_* と node --require ts-node/register で npm run 引数を安定化する / R16 → AM/AM2 の answers_raw.json と questions_raw.json の qNo・correctOption・選択肢を同期する / R17 → PM/PM1/PM2 は questions_transformed.json と subQuestions 解答欄を同期する / R18 → Mermaid のリンクラベルは -->|label| または ---|label| に正規化し、非ASCIIの円形節点ラベルは引用する / R19 → 新形式午後ヘッダーは CSS Modules を使う / R20 → AIAnswerBox の draftKey・文字数制限を維持する / R21 → 新形式午後の総合スコアは平均を /100、件数は解答欄数で表示する / R22 → section.answer・section.questions・空 subQuestions も解答欄化する / R23 → 日本語 ER 図・subgraph は sanitizeMermaid で描画可能に正規化する / R24 → GitHub Actions の artifact 取得は actions/download-artifact@v6 を使う / R24b → PRの追加修正はpull_request synchronizeでStaging再デプロイし、古い実行をconcurrencyでキャンセルする / R25 → SCPMExamView の解答例解説は ReactMarkdown で描画する / R26 → 解答例ラベルは不透明アンバー背景 + 濃色文字で視認性を保つ / R27 → 子設問を持つ説明だけの親見出しは解答欄化せず、午後データ監査を全区分で実行する / R28 → 午後問題は qNo 完全一致だけで解決し、位置番号フォールバックを再導入しない / R29 → answerChoices を持つ午後小問は radio/checkbox 選択式UIで採点・記録する / R30 → 午後OCRは複数大問PDF向けに JSON array を要求する / R31 → 午後変換はGeminiキーをローテーションする / R32 → 解答OCRは午後記述式の模範解答を抽出する / R33 → 受講者想定E2Eはfixture答案を入力し採点・保存まで検証する / R34 → 午後回答欄IDはresolvePMQuestionBaseIdで生成する / R35 → E2E証跡レポートは今回実行分の画像だけを掲載する / R36 → 午後問題データの英語混入は公式PDFベースの日本語本文へ補正する / R37 → FE公開問題は公開問題・科目A/BとしてExamsへ同期する / R38 → App Service 設定に AI_CHAT_FUNCTION_URL を含める / R39 → App Service と AI Function の両方に AI_CHAT_FUNCTION_SECRET を含める / R40 → devcontainer からの Cosmos Emulator は host.docker.internal もローカル接続として扱う / R41 → Web 側 CosmosClient は接続文字列確認後に動的 import する / R42 → Web unit test は happy-dom と scripts/run-vitest-batches.mjs 経由で少数ファイルずつ実行する"
 
 if ($FailOnFinding) { exit 1 }
 exit 0

--- a/.github/hooks/self-inspect.ps1
+++ b/.github/hooks/self-inspect.ps1
@@ -50,6 +50,9 @@
 #   R37. sync-db が FE 公開問題を秋期/午後として Exams に登録するパターン
 #   R38. 本番/Staging の App Service 設定から AI_CHAT_FUNCTION_URL が欠落するパターン
 #   R39. aiChat HMAC 署名用 AI_CHAT_FUNCTION_SECRET がデプロイ設定から欠落するパターン
+#   R40. devcontainer から host.docker.internal 経由の Cosmos Emulator 接続を扱えなくなるパターン
+#   R41. 接続文字列なしでも Web 側 Cosmos SDK をトップレベル import してテスト/起動が重くなるパターン
+#   R42. Web unit test がバッチ実行を経由せず worker 起動タイムアウトを再発させるパターン
 #
 # 引数:
 #   -Mode start|end   どちらのフェーズで呼ばれたか (出力タグの違いだけ)
@@ -1215,13 +1218,81 @@ if (Test-Path $questionClient) {
     }
 }
 
+# ---------------------------------------------------------------------------
+# R40: devcontainer から host.docker.internal 経由で Cosmos Emulator を使えること
+#      (workspace container では localhost がコンテナ自身を指すため、ホストOS上 Emulator を扱う導線を維持する)
+# ---------------------------------------------------------------------------
+$cosmosWebClient = Join-Path $WebRoot 'lib\cosmos.ts'
+$cosmosClientUtil = Join-Path $RepoRoot 'packages\data\src\utils\cosmos-client.ts'
+$cosmosSyncScript = Join-Path $RepoRoot 'packages\data\src\scripts\sync-db.ts'
+$cosmosVerifyScript = Join-Path $RepoRoot 'packages\data\src\scripts\verify-local-cosmos.ts'
+
+foreach ($path in @($cosmosWebClient, $cosmosClientUtil, $cosmosSyncScript, $cosmosVerifyScript)) {
+    if (-not (Test-Path $path)) { continue }
+    $raw = Get-Content -LiteralPath $path -Raw
+    if ($raw -notmatch 'host\.docker\.internal') {
+        Add-Finding -Rule 'R40-cosmos-emulator-devcontainer-host' -Severity 'Medium' `
+            -File $path `
+            -Detail 'devcontainer からホストOS上の Cosmos Emulator を使えるよう、host.docker.internal をローカル接続判定または検証導線に含めてください'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# R41: Web 側 Cosmos SDK をトップレベル実体 import しないこと
+#      (COSMOS_DB_CONNECTION が空のテスト/起動でも @azure/cosmos を読み込むと極端に遅くなる)
+# ---------------------------------------------------------------------------
+if (Test-Path $cosmosWebClient) {
+    $raw = Get-Content -LiteralPath $cosmosWebClient -Raw
+    if ($raw -match 'import\s+\{[^}]*\}\s+from\s+[''"]@azure/cosmos[''"]' -or
+        $raw -match 'import\s+\*\s+as\s+\w+\s+from\s+[''"]@azure/cosmos[''"]') {
+        Add-Finding -Rule 'R41-cosmos-web-sdk-lazy-import' -Severity 'Medium' `
+            -File $cosmosWebClient `
+            -Detail 'apps/web/lib/cosmos.ts は @azure/cosmos の型だけをトップレベル import し、CosmosClient 実体は接続文字列確認後に動的 import してください'
+    }
+    if ($raw -notmatch 'await\s+import\([''"]@azure/cosmos[''"]\)') {
+        Add-Finding -Rule 'R41-cosmos-web-sdk-lazy-import' -Severity 'Medium' `
+            -File $cosmosWebClient `
+            -Detail '接続文字列なしパスで SDK を読み込まないよう、CosmosClient 実体は getClient 内で await import してください'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# R42: Web unit test は少数ファイルのバッチ実行を経由すること
+#      (単一の vitest run で全ファイルを投入すると worker 起動タイムアウトが発生しやすい)
+# ---------------------------------------------------------------------------
+$webPackageJson = Join-Path $WebRoot 'package.json'
+$webVitestConfig = Join-Path $WebRoot 'vitest.config.ts'
+$webVitestBatchRunner = Join-Path $WebRoot 'scripts\run-vitest-batches.mjs'
+
+if (Test-Path $webPackageJson) {
+    $raw = Get-Content -LiteralPath $webPackageJson -Raw
+    if ($raw -notmatch '"test:run"\s*:\s*"node scripts/run-vitest-batches\.mjs"') {
+        Add-Finding -Rule 'R42-vitest-batched-unit-runner' -Severity 'Medium' `
+            -File $webPackageJson `
+            -Detail 'apps/web の test:run は worker 起動タイムアウトを避けるため scripts/run-vitest-batches.mjs 経由で実行してください'
+    }
+}
+if (-not (Test-Path $webVitestBatchRunner)) {
+    Add-Finding -Rule 'R42-vitest-batched-unit-runner' -Severity 'Medium' `
+        -File (Join-Path $WebRoot 'scripts') `
+        -Detail 'apps/web/scripts/run-vitest-batches.mjs がありません'
+}
+if (Test-Path $webVitestConfig) {
+    $raw = Get-Content -LiteralPath $webVitestConfig -Raw
+    if ($raw -notmatch "pool:\s*'threads'" -or $raw -notmatch 'maxWorkers:\s*4') {
+        Add-Finding -Rule 'R42-vitest-batched-unit-runner' -Severity 'Medium' `
+            -File $webVitestConfig `
+            -Detail 'vitest.config.ts は pool: threads と maxWorkers: 4 を維持し、devcontainer / pre-push の worker 起動を安定化してください'
+    }
+}
+
 $tag = if ($Mode -eq 'start') { 'SESSION-START' } else { 'SESSION-END' }
 Write-Host ""
 Write-Host "## [self-inspect $tag] 自己点検レポート"
 Write-Host ""
 
 if ($findings.Count -eq 0) {
-    Write-Host "✅ 検出された不整合はありません (R1 / R2 / R3 / R4 / R5 / R6 / R7 / R8 / R9 / R10 / R11 / R12 / R13 / R14 / R15 / R16 / R17 / R18 / R19 / R20 / R21 / R22 / R23 / R24 / R24b / R25 / R26 / R27 / R28 / R29 / R30 / R31 / R32 / R33 / R34 / R35 / R36 / R37 / R38 / R39)"
+    Write-Host "✅ 検出された不整合はありません (R1 / R2 / R3 / R4 / R5 / R6 / R7 / R8 / R9 / R10 / R11 / R12 / R13 / R14 / R15 / R16 / R17 / R18 / R19 / R20 / R21 / R22 / R23 / R24 / R24b / R25 / R26 / R27 / R28 / R29 / R30 / R31 / R32 / R33 / R34 / R35 / R36 / R37 / R38 / R39 / R40 / R41 / R42)"
     exit 0
 }
 
@@ -1235,7 +1306,7 @@ foreach ($f in $findings) {
 }
 
 Write-Host ""
-Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除 / R6 → error を弱点判定から除外 / R7 → 公式小問スコアを優先 / R8 → document-agent が docs/ を更新 / R9 → セッション進捗保存は currentSessionStats を使用 / R10 → Mermaid CODE_BLOCK マーカーを sanitizeMermaid で除去 / R11 → qNo 欠損を 99 にせず同期失敗として扱う / R12 → tracked 設定から接続文字列・API キー実値を除去 / R13 → download.ts で content-type と %PDF- ヘッダーを検証し、壊れた既存 PDF は再取得する / R14 → npx 直接 spawn ではなく process.execPath + ts-node/register を使う / R15 → npm_config_* と node --require ts-node/register で npm run 引数を安定化する / R16 → AM/AM2 の answers_raw.json と questions_raw.json の qNo・correctOption・選択肢を同期する / R17 → PM/PM1/PM2 は questions_transformed.json と subQuestions 解答欄を同期する / R18 → Mermaid のリンクラベルは -->|label| または ---|label| に正規化し、非ASCIIの円形節点ラベルは引用する / R19 → 新形式午後ヘッダーは CSS Modules を使う / R20 → AIAnswerBox の draftKey・文字数制限を維持する / R21 → 新形式午後の総合スコアは平均を /100、件数は解答欄数で表示する / R22 → section.answer・section.questions・空 subQuestions も解答欄化する / R23 → 日本語 ER 図・subgraph は sanitizeMermaid で描画可能に正規化する / R24 → GitHub Actions の artifact 取得は actions/download-artifact@v6 を使う / R24b → PRの追加修正はpull_request synchronizeでStaging再デプロイし、古い実行をconcurrencyでキャンセルする / R25 → SCPMExamView の解答例解説は ReactMarkdown で描画する / R26 → 解答例ラベルは不透明アンバー背景 + 濃色文字で視認性を保つ / R27 → 子設問を持つ説明だけの親見出しは解答欄化せず、午後データ監査を全区分で実行する / R28 → 午後問題は qNo 完全一致だけで解決し、位置番号フォールバックを再導入しない / R29 → answerChoices を持つ午後小問は radio/checkbox 選択式UIで採点・記録する / R30 → 午後OCRは複数大問PDF向けに JSON array を要求する / R31 → 午後変換はGeminiキーをローテーションする / R32 → 解答OCRは午後記述式の模範解答を抽出する / R33 → 受講者想定E2Eはfixture答案を入力し採点・保存まで検証する / R34 → 午後回答欄IDはresolvePMQuestionBaseIdで生成する / R35 → E2E証跡レポートは今回実行分の画像だけを掲載する / R36 → 午後問題データの英語混入は公式PDFベースの日本語本文へ補正する / R37 → FE公開問題は公開問題・科目A/BとしてExamsへ同期する / R38 → App Service 設定に AI_CHAT_FUNCTION_URL を含める / R39 → App Service と AI Function の両方に AI_CHAT_FUNCTION_SECRET を含める"
+Write-Host "ヒント: R1 → ensureContainer に置換 / R2 → catch 直下に console.error 追加 / R3 → CSS 宣言を @media 外に移動 / R4 → @media 内の grid-column override を削除 / R6 → error を弱点判定から除外 / R7 → 公式小問スコアを優先 / R8 → document-agent が docs/ を更新 / R9 → セッション進捗保存は currentSessionStats を使用 / R10 → Mermaid CODE_BLOCK マーカーを sanitizeMermaid で除去 / R11 → qNo 欠損を 99 にせず同期失敗として扱う / R12 → tracked 設定から接続文字列・API キー実値を除去 / R13 → download.ts で content-type と %PDF- ヘッダーを検証し、壊れた既存 PDF は再取得する / R14 → npx 直接 spawn ではなく process.execPath + ts-node/register を使う / R15 → npm_config_* と node --require ts-node/register で npm run 引数を安定化する / R16 → AM/AM2 の answers_raw.json と questions_raw.json の qNo・correctOption・選択肢を同期する / R17 → PM/PM1/PM2 は questions_transformed.json と subQuestions 解答欄を同期する / R18 → Mermaid のリンクラベルは -->|label| または ---|label| に正規化し、非ASCIIの円形節点ラベルは引用する / R19 → 新形式午後ヘッダーは CSS Modules を使う / R20 → AIAnswerBox の draftKey・文字数制限を維持する / R21 → 新形式午後の総合スコアは平均を /100、件数は解答欄数で表示する / R22 → section.answer・section.questions・空 subQuestions も解答欄化する / R23 → 日本語 ER 図・subgraph は sanitizeMermaid で描画可能に正規化する / R24 → GitHub Actions の artifact 取得は actions/download-artifact@v6 を使う / R24b → PRの追加修正はpull_request synchronizeでStaging再デプロイし、古い実行をconcurrencyでキャンセルする / R25 → SCPMExamView の解答例解説は ReactMarkdown で描画する / R26 → 解答例ラベルは不透明アンバー背景 + 濃色文字で視認性を保つ / R27 → 子設問を持つ説明だけの親見出しは解答欄化せず、午後データ監査を全区分で実行する / R28 → 午後問題は qNo 完全一致だけで解決し、位置番号フォールバックを再導入しない / R29 → answerChoices を持つ午後小問は radio/checkbox 選択式UIで採点・記録する / R30 → 午後OCRは複数大問PDF向けに JSON array を要求する / R31 → 午後変換はGeminiキーをローテーションする / R32 → 解答OCRは午後記述式の模範解答を抽出する / R33 → 受講者想定E2Eはfixture答案を入力し採点・保存まで検証する / R34 → 午後回答欄IDはresolvePMQuestionBaseIdで生成する / R35 → E2E証跡レポートは今回実行分の画像だけを掲載する / R36 → 午後問題データの英語混入は公式PDFベースの日本語本文へ補正する / R37 → FE公開問題は公開問題・科目A/BとしてExamsへ同期する / R38 → App Service 設定に AI_CHAT_FUNCTION_URL を含める / R39 → App Service と AI Function の両方に AI_CHAT_FUNCTION_SECRET を含める / R40 → devcontainer からの Cosmos Emulator は host.docker.internal もローカル接続として扱う / R41 → Web 側 CosmosClient は接続文字列確認後に動的 import する / R42 → Web unit test は scripts/run-vitest-batches.mjs 経由で少数ファイルずつ実行する"
 
 if ($FailOnFinding) { exit 1 }
 exit 0

--- a/.github/workflows/repository-guards.yml
+++ b/.github/workflows/repository-guards.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Run guard
         run: node scripts/guard-exam-data-fallback.mjs
 
+  afternoon-data-quality-audit:
+    # 午後問題データの欠落・構造不備を、standalone bundle 検証とは独立した必須ゲートとして検出する
+    name: Afternoon Data Quality Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - name: Run afternoon data audit
+        run: npm run audit:afternoon-data:ci
+
   standalone-bundle-data-check:
     # standalone build に packages/data の問題JSONが実際に同梱されているかを検証
     name: Standalone Bundle Data Check

--- a/apps/web/app/api/admin/analytics/route.ts
+++ b/apps/web/app/api/admin/analytics/route.ts
@@ -284,7 +284,7 @@ async function getDauMauStats(sinceISO: string) {
                     WHERE c.answeredAt >= @since AND IS_DEFINED(c.userId)`,
             parameters: [{ name: '@since', value: mauSinceISO }],
         }).fetchAll();
-        const mau = mauRaw.filter(r => r.userId).length;
+        const mau = mauRaw.filter((r: { userId?: string }) => r.userId).length;
 
         return { dau, mau };
     } catch (err) {

--- a/apps/web/app/api/exams/route.ts
+++ b/apps/web/app/api/exams/route.ts
@@ -24,7 +24,7 @@ async function getQuestionTotals(): Promise<Map<string, number>> {
             query: "SELECT c.examId, COUNT(1) AS total FROM c GROUP BY c.examId"
         }).fetchAll();
 
-        resources.forEach(({ examId, total }) => {
+        resources.forEach(({ examId, total }: { examId: string; total: number }) => {
             totals.set(examId, Number(total) || 0);
         });
     }

--- a/apps/web/lib/cosmos.ts
+++ b/apps/web/lib/cosmos.ts
@@ -1,8 +1,9 @@
-import { CosmosClient, Container } from '@azure/cosmos';
+import type { Container, CosmosClient } from '@azure/cosmos';
 import * as https from 'https';
 
 const CONNECTION_STRING = process.env.COSMOS_DB_CONNECTION || "";
 const DATABASE_NAME = "pm-exam-dx-db";
+const LOCAL_EMULATOR_HOSTS = ['localhost', '127.0.0.1', 'host.docker.internal', 'gateway.docker.internal'];
 const CONTAINER_PARTITION_KEYS: Record<string, string> = {
     Questions: "/examId",
     Users: "/id",
@@ -24,6 +25,14 @@ const CONTAINER_PARTITION_KEYS: Record<string, string> = {
 // Singleton instance
 let client: CosmosClient | undefined;
 
+const isLocalEmulatorConnectionString = (connectionString: string) =>
+    LOCAL_EMULATOR_HOSTS.some(host => connectionString.includes(host));
+
+const normalizeLocalEmulatorConnectionString = (connectionString: string) =>
+    connectionString.includes('localhost')
+        ? connectionString.replace('localhost', '127.0.0.1')
+        : connectionString;
+
 // Lazy initialization function
 const getClient = async (): Promise<CosmosClient | undefined> => {
     if (client) {
@@ -38,13 +47,9 @@ const getClient = async (): Promise<CosmosClient | undefined> => {
     }
 
     try {
-        let connStr = CONNECTION_STRING;
-        const isLocalEmulator = connStr.includes("localhost") || connStr.includes("127.0.0.1");
-        
-        // Fix for local emulator
-        if (connStr.includes("localhost")) {
-            connStr = connStr.replace("localhost", "127.0.0.1");
-        }
+        const isLocalEmulator = isLocalEmulatorConnectionString(CONNECTION_STRING);
+        const connStr = normalizeLocalEmulatorConnectionString(CONNECTION_STRING);
+        const { CosmosClient } = await import('@azure/cosmos');
 
         // ローカルエミュレータの場合のみTLS検証を無効化
         // 本番環境（Azure CosmosDB）では適切な証明書が使用される

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
         "start:standalone": "node server.js",
         "lint": "eslint app components hooks lib --ext .js,.jsx,.ts,.tsx",
         "test": "vitest",
-        "test:run": "vitest run",
+        "test:run": "node scripts/run-vitest-batches.mjs",
         "test:coverage": "vitest run --coverage",
         "test:e2e": "npx playwright test",
         "test:e2e:ui": "npx playwright test --ui"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^5.1.2",
+        "happy-dom": "^20.9.0",
         "jsdom": "^27.4.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.18"

--- a/apps/web/scripts/run-vitest-batches.mjs
+++ b/apps/web/scripts/run-vitest-batches.mjs
@@ -65,6 +65,7 @@ function runVitest(files, label, workers) {
             },
             shell: useShell,
             stdio: 'inherit',
+            shell: process.platform === 'win32',
         }
     );
 

--- a/apps/web/scripts/run-vitest-batches.mjs
+++ b/apps/web/scripts/run-vitest-batches.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(webRoot, '../..');
+const testRoot = path.join(webRoot, '__tests__');
+const pool = process.env.VITEST_POOL ?? 'threads';
+const vitestBin = path.join(
+    repoRoot,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'vitest.cmd' : 'vitest'
+);
+
+const batchSize = Math.max(1, Number.parseInt(process.env.VITEST_BATCH_SIZE ?? '4', 10));
+const maxWorkers = Math.max(1, Number.parseInt(process.env.VITEST_MAX_WORKERS ?? '4', 10));
+
+function collectTestFiles(dir) {
+    const entries = readdirSync(dir).sort((a, b) => a.localeCompare(b));
+    const files = [];
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry);
+        const stats = statSync(fullPath);
+        if (stats.isDirectory()) {
+            files.push(...collectTestFiles(fullPath));
+            continue;
+        }
+        if (/\.(test|spec)\.(js|mjs|cjs|ts|mts|cts|jsx|tsx)$/.test(entry)) {
+            files.push(path.relative(webRoot, fullPath).replace(/\\/g, '/'));
+        }
+    }
+
+    return files;
+}
+
+const testFiles = collectTestFiles(testRoot);
+
+if (testFiles.length === 0) {
+    console.error('[vitest-batches] No test files found.');
+    process.exit(1);
+}
+
+const totalBatches = Math.ceil(testFiles.length / batchSize);
+
+for (let offset = 0; offset < testFiles.length; offset += batchSize) {
+    const batch = testFiles.slice(offset, offset + batchSize);
+    const batchNo = offset / batchSize + 1;
+    const workersForBatch = Math.min(maxWorkers, batch.length);
+
+    console.log(
+        `\n[vitest-batches] Batch ${batchNo}/${totalBatches}: ${batch.length} file(s), pool=${pool}, maxWorkers=${workersForBatch}`
+    );
+
+    const result = spawnSync(
+        vitestBin,
+        ['run', ...batch, `--pool=${pool}`, `--maxWorkers=${workersForBatch}`],
+        {
+            cwd: webRoot,
+            env: {
+                ...process.env,
+                VITEST_MAX_WORKERS: String(workersForBatch),
+            },
+            stdio: 'inherit',
+        }
+    );
+
+    if (result.error) {
+        console.error(`[vitest-batches] Failed to run batch ${batchNo}:`, result.error);
+        process.exit(1);
+    }
+
+    if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+    }
+}
+
+console.log(`\n[vitest-batches] Completed ${testFiles.length} test file(s).`);

--- a/apps/web/scripts/run-vitest-batches.mjs
+++ b/apps/web/scripts/run-vitest-batches.mjs
@@ -16,6 +16,7 @@ const vitestBin = path.join(
     '.bin',
     process.platform === 'win32' ? 'vitest.cmd' : 'vitest'
 );
+const useShell = process.platform === 'win32';
 
 const batchSize = Math.max(1, Number.parseInt(process.env.VITEST_BATCH_SIZE ?? '4', 10));
 const maxWorkers = Math.max(1, Number.parseInt(process.env.VITEST_MAX_WORKERS ?? '4', 10));
@@ -62,6 +63,7 @@ function runVitest(files, label, workers) {
                 ...process.env,
                 VITEST_MAX_WORKERS: String(workers),
             },
+            shell: useShell,
             stdio: 'inherit',
         }
     );

--- a/apps/web/scripts/run-vitest-batches.mjs
+++ b/apps/web/scripts/run-vitest-batches.mjs
@@ -48,35 +48,55 @@ if (testFiles.length === 0) {
 
 const totalBatches = Math.ceil(testFiles.length / batchSize);
 
-for (let offset = 0; offset < testFiles.length; offset += batchSize) {
-    const batch = testFiles.slice(offset, offset + batchSize);
-    const batchNo = offset / batchSize + 1;
-    const workersForBatch = Math.min(maxWorkers, batch.length);
-
+function runVitest(files, label, workers) {
     console.log(
-        `\n[vitest-batches] Batch ${batchNo}/${totalBatches}: ${batch.length} file(s), pool=${pool}, maxWorkers=${workersForBatch}`
+        `\n[vitest-batches] ${label}: ${files.length} file(s), pool=${pool}, maxWorkers=${workers}`
     );
 
     const result = spawnSync(
         vitestBin,
-        ['run', ...batch, `--pool=${pool}`, `--maxWorkers=${workersForBatch}`],
+        ['run', ...files, `--pool=${pool}`, `--maxWorkers=${workers}`],
         {
             cwd: webRoot,
             env: {
                 ...process.env,
-                VITEST_MAX_WORKERS: String(workersForBatch),
+                VITEST_MAX_WORKERS: String(workers),
             },
             stdio: 'inherit',
         }
     );
 
     if (result.error) {
-        console.error(`[vitest-batches] Failed to run batch ${batchNo}:`, result.error);
-        process.exit(1);
+        console.error(`[vitest-batches] Failed to run ${label}:`, result.error);
+        return { ok: false, status: 1 };
     }
 
-    if (result.status !== 0) {
-        process.exit(result.status ?? 1);
+    return { ok: result.status === 0, status: result.status ?? 1 };
+}
+
+for (let offset = 0; offset < testFiles.length; offset += batchSize) {
+    const batch = testFiles.slice(offset, offset + batchSize);
+    const batchNo = offset / batchSize + 1;
+    const workersForBatch = Math.min(maxWorkers, batch.length);
+
+    const result = runVitest(batch, `Batch ${batchNo}/${totalBatches}`, workersForBatch);
+    if (result.ok) {
+        continue;
+    }
+
+    if (batch.length === 1) {
+        process.exit(result.status);
+    }
+
+    console.warn(
+        `[vitest-batches] Batch ${batchNo}/${totalBatches} failed; retrying files individually with maxWorkers=1.`
+    );
+
+    for (const file of batch) {
+        const retry = runVitest([file], `Batch ${batchNo}/${totalBatches} retry: ${file}`, 1);
+        if (!retry.ok) {
+            process.exit(retry.status);
+        }
     }
 }
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
         globals: true,
         setupFiles: ['./vitest.setup.ts'],
         testTimeout: 30000, // API の動的インポート（CosmosDB SDK 等）が重い場合の対応
+        pool: 'threads',
+        maxWorkers: 4, // devcontainer / pre-push で worker 起動タイムアウトを避ける
         include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
         exclude: ['node_modules', '.next', 'e2e'],
         coverage: {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
 export default defineConfig({
     plugins: [react()],
     test: {
-        environment: 'jsdom',
+        environment: 'happy-dom',
         globals: true,
         setupFiles: ['./vitest.setup.ts'],
         testTimeout: 30000, // API の動的インポート（CosmosDB SDK 等）が重い場合の対応

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -26,6 +26,12 @@ Object.defineProperty(window, 'localStorage', {
     value: localStorageMock,
 });
 
+Object.defineProperty(window, 'alert', {
+    value: () => {},
+    writable: true,
+    configurable: true,
+});
+
 // Mock crypto.randomUUID
 Object.defineProperty(window, 'crypto', {
     value: {

--- a/docs/02_design/01_ConfigurationDesign.md
+++ b/docs/02_design/01_ConfigurationDesign.md
@@ -82,12 +82,14 @@
 
 ### 3.1 Web (`apps/web`)
 
-- **Framework**: Next.js 16.2.1 (App Router)
+- **Framework**: Next.js 16.2.4 (App Router)
 - **Node.js**: v20 (LTS)
 - **Build**: Standalone モード無効（Azure SWA 最適化）
 - **Styling**: CSS Modules (`*.module.css`)
 - **Testing**:
   - Unit: Vitest + @testing-library/react
+  - `test:run` は `scripts/run-vitest-batches.mjs` でテストファイルを 4 件ずつ分割実行する
+  - Unit 実行時は `vitest.config.ts` の `pool: 'threads'` と `maxWorkers: 4` で worker 起動数を抑制し、devcontainer / pre-push での worker 起動タイムアウトを防止する
   - E2E: Playwright
 - **Lint**: `eslint app components hooks lib --ext .js,.jsx,.ts,.tsx` で `packages/config/eslint-preset` を使用
 - **TSConfig**: `packages/config/tsconfig.base.json` を extends
@@ -170,11 +172,15 @@ COSMOS_DB_CONNECTION=<cosmos_connection>
 1. `node scripts/guard-exam-data-fallback.mjs`
    - 午後試験データ fallback の本番防壁を検証します。
 2. `pwsh .github/hooks/self-inspect.ps1 -Mode end -FailOnFinding`
-  - 過去インシデントに基づく再発防止ルール R1〜R12 を検証します。
+  - 過去インシデントに基づく再発防止ルール R1〜R42 を検証します。
 
 `self-inspect` の R8 は、`apps/`、`packages/`、`.github/hooks/`、`.github/workflows/`、`.husky/`、主要なルート設定ファイルに実装変更があるにもかかわらず `docs/` 配下の更新がない場合に検出します。検出時はコミットを中止し、該当する設計書・手順書の更新を `document-agent` の担当作業として促します。
 
 `self-inspect` の R12 は、tracked 設定ファイルに Cosmos / Storage 接続文字列の `AccountKey` 実値、Google API キー形式の実値、秘密鍵ヘッダーが混入していないかを値非表示で検出します。
+
+`self-inspect` の R40 / R41 は、devcontainer からホスト OS 上の Cosmos Emulator を扱える接続判定と、接続文字列未設定時に Web 側で `@azure/cosmos` SDK をトップレベル実体 import しないことを検出します。
+
+`self-inspect` の R42 は、Web unit test が `scripts/run-vitest-batches.mjs` 経由の少数ファイルバッチ実行から直接 `vitest run` へ戻っていないかを検出します。
 
 テスト実行は `pre-push` に集約し、コミット時の待ち時間を抑えつつ、push 前にユニットテストを必ず通す構成とします。
 

--- a/docs/02_design/01_ConfigurationDesign.md
+++ b/docs/02_design/01_ConfigurationDesign.md
@@ -87,9 +87,9 @@
 - **Build**: Standalone モード無効（Azure SWA 最適化）
 - **Styling**: CSS Modules (`*.module.css`)
 - **Testing**:
-  - Unit: Vitest + @testing-library/react
-  - `test:run` は `scripts/run-vitest-batches.mjs` でテストファイルを 4 件ずつ分割実行する
-  - Unit 実行時は `vitest.config.ts` の `pool: 'threads'` と `maxWorkers: 4` で worker 起動数を抑制し、devcontainer / pre-push での worker 起動タイムアウトを防止する
+  - Unit: Vitest + @testing-library/react + happy-dom
+  - `test:run` は `scripts/run-vitest-batches.mjs` でテストファイルを 4 件ずつ分割実行し、失敗した batch は 1 ファイルずつ再実行する
+  - Unit 実行時は `vitest.config.ts` の `environment: 'happy-dom'`、`pool: 'threads'`、`maxWorkers: 4` で DOM 初期化と worker 起動数を抑制し、devcontainer / pre-push での worker 起動タイムアウトを防止する
   - E2E: Playwright
 - **Lint**: `eslint app components hooks lib --ext .js,.jsx,.ts,.tsx` で `packages/config/eslint-preset` を使用
 - **TSConfig**: `packages/config/tsconfig.base.json` を extends
@@ -180,7 +180,7 @@ COSMOS_DB_CONNECTION=<cosmos_connection>
 
 `self-inspect` の R40 / R41 は、devcontainer からホスト OS 上の Cosmos Emulator を扱える接続判定と、接続文字列未設定時に Web 側で `@azure/cosmos` SDK をトップレベル実体 import しないことを検出します。
 
-`self-inspect` の R42 は、Web unit test が `scripts/run-vitest-batches.mjs` 経由の少数ファイルバッチ実行から直接 `vitest run` へ戻っていないかを検出します。
+`self-inspect` の R42 は、Web unit test が `happy-dom` と `scripts/run-vitest-batches.mjs` 経由の少数ファイルバッチ実行から、重い `jsdom` 環境や直接 `vitest run` へ戻っていないかを検出します。
 
 テスト実行は `pre-push` に集約し、コミット時の待ち時間を抑えつつ、push 前にユニットテストを必ず通す構成とします。
 

--- a/docs/02_design/05_DataSyncDesign.md
+++ b/docs/02_design/05_DataSyncDesign.md
@@ -4,6 +4,7 @@
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-18 | 午後データ品質監査を Repository Guards の CI 必須ゲートへ追加し、blocking finding と例外管理ルールを定義 |
 | 2026-05-09 | AIを使う問題データ抽出は Gemini API ではなく、同一ローカルネットワーク上の Ollama `gemma4:31b` を標準とする運用へ更新 |
 | 2026-05-08 | 午後解答PDFの Gemini OCR プロンプトを午前択一表専用から記述式解答対応へ拡張し、self-inspect R32 を追加 |
 | 2026-05-08 | 全試験区分の午後データ品質監査 `audit:afternoon-data`、DB/AU/SM など未抽出区分の抽出必要性、親見出し800字欄化の再発防止を追加 |
@@ -159,6 +160,7 @@ Windows 環境では `npx` を子プロセスから直接 spawn すると `spawn
 ```powershell
 npm run audit:afternoon-data
 npm run audit:afternoon-data -- --json
+npm run audit:afternoon-data:ci
 ```
 
 Windows 環境では npm が `--json` や `--categories=SA` を npm 設定として扱う場合があるため、監査スクリプトは `npm_config_json` / `npm_config_categories` / `npm_config_exclude` / `npm_config_fail_on_findings` も読み取る。
@@ -175,6 +177,38 @@ Windows 環境では npm が `--json` や `--categories=SA` を npm 設定とし
 - PM / PM1 の短答・式・表中属性回答で字数条件がなく、UI上で800字原稿用紙欄に見える疑い
 
 `self-inspect` R27 は、親見出しを直接解答欄化しない UI 判定、PM / PM1 の字数制限なし短答を公式解答例の約1.2倍（10字単位切上げ、最小20字）の表示用原稿用紙欄へ分岐する UI 判定、`scripts/audit-afternoon-data-quality.mjs` の存在と `shortAnswerNoLimit` 監査ルールを検査する。表示用マス数は採点を止める文字数制限ではなく、明示字数制限がない設問では超過しても警告や採点ブロックを出さない。データ修正 PR では、監査結果、公式PDF照合対象、抽出対象区分、未修正の残リスクを PR 本文または `docs/04_reports/` の報告書に記録する。
+
+Repository Guards では `afternoon-data-quality-audit` ジョブを `exam-data-fallback-guard`、`standalone-bundle-data-check` と独立して実行する。standalone bundle の同梱確認はビルド成果物の検証、午後データ品質監査はローカル JSON の欠落・構造不備検出に限定し、役割を重複させない。
+
+CI では `npm run audit:afternoon-data:ci` を実行し、`scripts/audit-afternoon-data-quality.mjs --json --fail-on=blocking` と同等の条件で失敗させる。blocking finding は次のルールとする。
+
+- `answerMissing`: 解答欄に公式解答・模範解答相当の値がない
+- `explanationMissing`: 解答欄に解説・コメント相当の値がない
+- `underlineRefMissing`: 設問の下線参照番号が本文側に存在しない
+- `parentDirectWithChildren`: 子設問を持つ親設問が直接解答欄化される
+- `multipleLimits`: 1設問に複数の字数条件が混在する
+- `symbolNoStructuralChoices`: 記号回答なのに `choices` / `options` / `answerChoices` がない
+- `broadPromptNoLimit`: 広い回答要求に字数条件がない
+- `englishTextFragments`: 午後問題本文・解説に英語断片が混入している
+- `missingTargetCategory`: 標準確認対象区分に午後データが存在しない
+
+`underlineNoEvidence`、`shortAnswerNoLimit`、`sharedBroadChoiceGroup` は既存データの調査・改善用 finding として JSON には出力するが、直ちに CI を失敗させる blocking finding には含めない。
+
+例外が必要な場合は、公式PDF照合済みであること、恒久対応の Issue / PR があること、期限または見直し条件があることを PR 本文に記録する。機械的な例外は `scripts/audit-afternoon-data-quality.allowlist.json` または `--allowlist=<path>` で次の形式にする。`rule` と `reason` は必須で、`examId`、`file`、`qNo`、`subQNo`、`category` は必要な粒度で指定する。
+
+```json
+{
+  "allowed": [
+    {
+      "rule": "broadPromptNoLimit",
+      "examId": "SA-2024-Spring-PM1",
+      "qNo": 1,
+      "subQNo": "設問1",
+      "reason": "公式PDFで論述設問として確認済み。後続PRで構造化予定。"
+    }
+  ]
+}
+```
 
 #### 7.2.1 Gemini OCR Stage B 対象限定実行
 

--- a/docs/02_design/05_DataSyncDesign.md
+++ b/docs/02_design/05_DataSyncDesign.md
@@ -194,7 +194,7 @@ CI では `npm run audit:afternoon-data:ci` を実行し、`scripts/audit-aftern
 
 `underlineNoEvidence`、`shortAnswerNoLimit`、`sharedBroadChoiceGroup` は既存データの調査・改善用 finding として JSON には出力するが、直ちに CI を失敗させる blocking finding には含めない。
 
-例外が必要な場合は、公式PDF照合済みであること、恒久対応の Issue / PR があること、期限または見直し条件があることを PR 本文に記録する。機械的な例外は `scripts/audit-afternoon-data-quality.allowlist.json` または `--allowlist=<path>` で次の形式にする。`rule` と `reason` は必須で、`examId`、`file`、`qNo`、`subQNo`、`category` は必要な粒度で指定する。
+例外が必要な場合は、公式PDF照合済みであること、恒久対応の Issue / PR があること、期限または見直し条件があることを PR 本文に記録する。機械的な例外は `scripts/audit-afternoon-data-quality.allowlist.json` または `--allowlist=<path>` で次の形式にする。`rule` と `reason` は必須で、通常の finding は `examId` または `file` も必須とする。`missingTargetCategory` だけは `category` を必須とする。`qNo`、`subQNo` は必要に応じて追加し、`rule` と `reason` だけで全件許可する allowlist は禁止する。
 
 ```json
 {

--- a/docs/02_design/05_DataSyncDesign.md
+++ b/docs/02_design/05_DataSyncDesign.md
@@ -4,6 +4,7 @@
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-18 | 公式PDF出典メタデータ `officialSource` と照合済み/未照合監査の運用を追加 |
 | 2026-05-18 | 午後データ品質監査を Repository Guards の CI 必須ゲートへ追加し、blocking finding と例外管理ルールを定義 |
 | 2026-05-09 | AIを使う問題データ抽出は Gemini API ではなく、同一ローカルネットワーク上の Ollama `gemma4:31b` を標準とする運用へ更新 |
 | 2026-05-08 | 午後解答PDFの Gemini OCR プロンプトを午前択一表専用から記述式解答対応へ拡張し、self-inspect R32 を追加 |
@@ -160,6 +161,7 @@ Windows 環境では `npx` を子プロセスから直接 spawn すると `spawn
 ```powershell
 npm run audit:afternoon-data
 npm run audit:afternoon-data -- --json
+npm run audit:afternoon-source
 npm run audit:afternoon-data:ci
 ```
 
@@ -209,6 +211,41 @@ CI では `npm run audit:afternoon-data:ci` を実行し、`scripts/audit-aftern
   ]
 }
 ```
+
+##### 7.2.0.1 公式PDF出典メタデータと照合証跡
+
+新規抽出・補正データでは、公式PDFまたは公式HTMLとの照合結果を問題データ内に保持する。付与先は、根拠の粒度に応じて大問、設問、解答欄のいずれかの `officialSource` とする。下位要素に個別の `officialSource` がない場合、監査では上位要素の `officialSource` を継承した照合済み扱いにする。
+
+`officialSource` は次のフィールドを必須とする。
+
+- `sourceUrl`: IPA公式PDFまたは公式HTMLのURL
+- `sourcePage` または `sourcePages`: PDFページ番号またはページ範囲。紙面上の表記差がある場合は文字列も許可する
+- `verifiedAt`: ISO 8601形式の照合日時
+- `verificationMethod`: `official-pdf-manual`、`official-pdf-ocr-review` など、照合方法を表す文字列
+
+例:
+
+```json
+{
+  "officialSource": {
+    "sourceUrl": "https://www.ipa.go.jp/shiken/mondai-kaiotu/2025r07.html",
+    "sourcePages": [3, 4],
+    "verifiedAt": "2026-05-18T00:00:00Z",
+    "verificationMethod": "official-pdf-manual",
+    "verifiedBy": "data-management-specialist",
+    "note": "問題PDFと解答PDFを照合済み"
+  }
+}
+```
+
+照合済み・未照合の一覧は、午後データ監査の `officialSource` セクションで確認する。
+
+```powershell
+npm run audit:afternoon-source
+npm run audit:afternoon-data -- --json --source-report=full
+```
+
+`source-report=summary` は未照合・不完全な項目を最大50件だけ出力し、`source-report=full` は全件を出力する。既存データへ一括付与するまでは、`officialSourceMissing` と `officialSourceIncomplete` は blocking finding に含めず、段階的な照合作業の棚卸しとして扱う。ただし、今後追加・補正する午後データでは、PR本文に公式PDF照合対象と `officialSource` 付与有無を記録する。
 
 #### 7.2.1 Gemini OCR Stage B 対象限定実行
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,6 +307,7 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^5.1.2",
+        "happy-dom": "^20.9.0",
         "jsdom": "^27.4.0",
         "typescript": "^5.0.0",
         "vitest": "^4.0.18"
@@ -1043,7 +1044,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1468,7 +1468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1509,7 +1508,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3552,7 +3550,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3789,7 +3786,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5696,6 +5692,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5716,6 +5713,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5729,6 +5727,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5739,6 +5738,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5753,7 +5753,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -5854,7 +5855,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -6096,7 +6098,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6138,7 +6139,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6150,7 +6150,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -6191,6 +6190,23 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -6237,7 +6253,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6888,7 +6903,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7458,7 +7472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7997,7 +8010,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8380,7 +8392,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8766,7 +8777,6 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -8819,7 +8829,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.0",
@@ -9098,7 +9109,6 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9163,7 +9173,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9346,7 +9355,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10365,6 +10373,47 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/has-bigints": {
@@ -11944,6 +11993,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -18857,7 +18907,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
@@ -19627,7 +19676,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19723,7 +19771,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -19875,7 +19922,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19888,7 +19934,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -19910,8 +19955,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "9.0.1",
@@ -19944,7 +19988,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -20035,8 +20078,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -22103,8 +22145,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -22407,7 +22448,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22849,7 +22889,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:unit": "turbo run test:run --filter=web",
     "test:e2e": "cd apps/web && npx playwright test",
     "audit:afternoon-data": "node scripts/audit-afternoon-data-quality.mjs",
+    "audit:afternoon-data:ci": "node scripts/audit-afternoon-data-quality.mjs --json --fail-on=blocking",
     "complete:afternoon-data": "node scripts/complete-afternoon-missing-fields.mjs",
     "guard:exam-data": "node scripts/guard-exam-data-fallback.mjs",
     "guard:exam-data:test": "node scripts/__tests__/guard-exam-data-fallback.test.mjs",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:unit": "turbo run test:run --filter=web",
     "test:e2e": "cd apps/web && npx playwright test",
     "audit:afternoon-data": "node scripts/audit-afternoon-data-quality.mjs",
+    "audit:afternoon-source": "node scripts/audit-afternoon-data-quality.mjs --json --source-report=full",
     "audit:afternoon-data:ci": "node scripts/audit-afternoon-data-quality.mjs --json --fail-on=blocking",
     "complete:afternoon-data": "node scripts/complete-afternoon-missing-fields.mjs",
     "guard:exam-data": "node scripts/guard-exam-data-fallback.mjs",

--- a/packages/data/src/scripts/sync-db.ts
+++ b/packages/data/src/scripts/sync-db.ts
@@ -5,6 +5,9 @@ import * as glob from 'glob';
 import { CosmosClient } from '@azure/cosmos';
 import * as dotenv from 'dotenv';
 import * as https from 'https';
+import { isLocalEmulatorConnection } from '../utils/cosmos-client';
+
+// devcontainer からホストOS上の Emulator へ接続する host.docker.internal も utils 側でローカル接続として扱う。
 
 // Load env vars
 // Try loading from web/api local.settings.json or .env.local
@@ -77,7 +80,7 @@ async function cleanLearningRecords() {
         process.exit(1);
     }
 
-    const isLocal = CONNECTION_STRING.includes('localhost') || CONNECTION_STRING.includes('127.0.0.1');
+    const isLocal = isLocalEmulatorConnection(CONNECTION_STRING);
     let finalConnectionString = CONNECTION_STRING;
     let clientOptions: any = {};
 

--- a/packages/data/src/utils/cosmos-client.ts
+++ b/packages/data/src/utils/cosmos-client.ts
@@ -10,6 +10,8 @@
 import { CosmosClient, CosmosClientOptions } from '@azure/cosmos';
 import * as https from 'https';
 
+const LOCAL_EMULATOR_HOSTS = ['localhost', '127.0.0.1', 'host.docker.internal', 'gateway.docker.internal'];
+
 export interface CreateCosmosClientOptions {
     connectionString: string;
     allowInsecureLocalConnection?: boolean;
@@ -18,7 +20,7 @@ export interface CreateCosmosClientOptions {
 /**
  * CosmosDBクライアントを作成します
  * 
- * ローカルエミュレータ (localhost/127.0.0.1) 接続時のみ、
+ * ローカルエミュレータ (localhost/127.0.0.1/host.docker.internal) 接続時のみ、
  * 自己署名証明書を許可するためTLS検証を無効化します。
  * 
  * @param options - 接続オプション
@@ -35,7 +37,7 @@ export function createCosmosClient(options: CreateCosmosClientOptions): CosmosCl
         throw new Error('CosmosDB接続文字列が設定されていません');
     }
     
-    const isLocalEmulator = connectionString.includes('localhost') || connectionString.includes('127.0.0.1');
+    const isLocalEmulator = isLocalEmulatorConnection(connectionString);
     
     const clientOptions: CosmosClientOptions = {
         connectionString,
@@ -62,5 +64,5 @@ export function createCosmosClient(options: CreateCosmosClientOptions): CosmosCl
  * 接続文字列がローカルエミュレータかどうかを判定
  */
 export function isLocalEmulatorConnection(connectionString: string): boolean {
-    return connectionString.includes('localhost') || connectionString.includes('127.0.0.1');
+    return LOCAL_EMULATOR_HOSTS.some(host => connectionString.includes(host));
 }

--- a/packages/shared/src/types/models.ts
+++ b/packages/shared/src/types/models.ts
@@ -26,15 +26,39 @@ export const OptionSchema = z.object({
     text: z.string(),
 });
 
+export const OfficialSourcePageSchema = z.union([
+    z.number().int().positive(),
+    z.string().min(1),
+]);
+
+export const OfficialSourceMetadataSchema = z.object({
+    sourceUrl: z.string().url(),
+    sourcePage: OfficialSourcePageSchema.optional(),
+    sourcePages: z.array(OfficialSourcePageSchema).min(1).optional(),
+    verifiedAt: z.string().datetime(),
+    verificationMethod: z.string().min(1),
+    verifiedBy: z.string().optional(),
+    note: z.string().optional(),
+}).refine(
+    (source) => source.sourcePage !== undefined || source.sourcePages !== undefined,
+    { message: 'sourcePage or sourcePages is required', path: ['sourcePage'] },
+);
+
+export type OfficialSourceMetadata = z.infer<typeof OfficialSourceMetadataSchema>;
+
+const SubQuestionLeafSchema = z.object({
+    label: z.string(), // "(1)"
+    text: z.string(),
+    point: z.number().optional(), // Added for Scoring
+    officialSource: OfficialSourceMetadataSchema.optional(),
+});
+
 export const SubQuestionSchema = z.object({
     subQNo: z.string(), // "設問1"
     text: z.string(),
-    subQuestions: z.array(z.object({
-        label: z.string(), // "(1)"
-        text: z.string(),
-        point: z.number().optional(), // Added for Scoring
-    })).optional(),
+    subQuestions: z.array(SubQuestionLeafSchema).optional(),
     choices: z.record(z.string()).optional(),
+    officialSource: OfficialSourceMetadataSchema.optional(),
 });
 
 export const QuestionSchema = z.object({
@@ -50,6 +74,7 @@ export const QuestionSchema = z.object({
     explanation: z.string().optional(), // Markdown
     transcription: z.string().optional(), // 音声読み上げ用テキスト(Future)
     createdAt: z.string().datetime().optional(),
+    officialSource: OfficialSourceMetadataSchema.optional(),
 
     // PM specific
     isPM: z.boolean().optional(),

--- a/scripts/audit-afternoon-data-quality.mjs
+++ b/scripts/audit-afternoon-data-quality.mjs
@@ -19,6 +19,17 @@ const underlineEvidencePattern = /<u\b|underline|text-decoration/i;
 const choiceKeys = ['choices', 'options', 'answerChoices'];
 const answerFieldKeys = ['answer', 'modelAnswer', 'correctOption', 'correctAnswer', 'correct', 'expectedAnswer', 'answerExample', 'sampleAnswer'];
 const explanationFieldKeys = ['explanation', 'commentary', '解説'];
+const blockingFindingRules = [
+    'answerMissing',
+    'explanationMissing',
+    'underlineRefMissing',
+    'parentDirectWithChildren',
+    'multipleLimits',
+    'symbolNoStructuralChoices',
+    'broadPromptNoLimit',
+    'englishTextFragments',
+    'missingTargetCategory',
+];
 
 const args = new Map(
     process.argv.slice(2).map((arg) => {
@@ -32,12 +43,20 @@ function argValue(name, envName = name.replaceAll('-', '_')) {
 
 const jsonOutput = argValue('json') === 'true';
 const failOnFindings = argValue('fail-on-findings') === 'true';
+const failOnBlocking = argValue('fail-on-blocking') === 'true';
+const failMode = argValue('fail-on') || (failOnBlocking ? 'blocking' : failOnFindings ? 'all' : 'none');
 const categoriesArg = argValue('categories');
 const excludeArg = argValue('exclude');
+const allowlistArg = argValue('allowlist');
 const includeCategories = categoriesArg
     ? new Set(categoriesArg.split(',').map((value) => value.trim()).filter(Boolean))
     : null;
 const excludeCategories = new Set((excludeArg || '').split(',').map((value) => value.trim()).filter(Boolean));
+
+if (!['none', 'all', 'blocking'].includes(failMode)) {
+    console.error(`invalid --fail-on value: ${failMode} (expected: none, all, blocking)`);
+    process.exit(1);
+}
 
 function normalizePath(filePath) {
     return path.relative(repoRoot, filePath).replaceAll('\\', '/');
@@ -45,6 +64,27 @@ function normalizePath(filePath) {
 
 function readJson(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function resolveRepoPath(value) {
+    return path.isAbsolute(value) ? value : path.join(repoRoot, value);
+}
+
+function readAllowlist(filePath) {
+    if (!filePath || !fs.existsSync(filePath)) return [];
+    const raw = readJson(filePath);
+    const entries = Array.isArray(raw) ? raw : raw.allowed;
+    if (!Array.isArray(entries)) {
+        console.error(`invalid allowlist format: ${normalizePath(filePath)} must be an array or { "allowed": [] }`);
+        process.exit(1);
+    }
+    for (const entry of entries) {
+        if (!hasText(entry?.rule) || !hasText(entry?.reason)) {
+            console.error(`invalid allowlist entry in ${normalizePath(filePath)}: rule and reason are required`);
+            process.exit(1);
+        }
+    }
+    return entries;
 }
 
 function getExamFile(examId) {
@@ -195,6 +235,25 @@ function addExample(examples, key, value) {
     if (examples[key].length < 8) examples[key].push(value);
 }
 
+function addBlockingFinding(findings, rule, value) {
+    findings.push({ rule, ...value });
+}
+
+function valuesMatch(expected, actual) {
+    if (expected === undefined) return true;
+    if (actual === undefined || actual === null) return false;
+    return String(expected) === String(actual);
+}
+
+function isAllowlisted(finding, entry) {
+    return valuesMatch(entry.rule, finding.rule)
+        && valuesMatch(entry.examId, finding.examId)
+        && valuesMatch(entry.file, finding.file)
+        && valuesMatch(entry.category, finding.category)
+        && valuesMatch(entry.qNo, finding.qNo)
+        && valuesMatch(entry.subQNo, finding.subQNo);
+}
+
 function textFragments(question) {
     const fragments = [
         ['theme', question?.theme],
@@ -226,6 +285,7 @@ if (!fs.existsSync(questionsRoot)) {
 const byCategory = new Map();
 const bySuffix = new Map();
 const examples = {};
+const blockingFindings = [];
 const categoryExamCounts = new Map();
 let total = makeStats();
 
@@ -264,28 +324,32 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
             const fragment = text(value).trim();
             if (!fragment || !englishTextFragmentPattern.test(fragment)) continue;
             fileStats.englishTextFragments++;
-            addExample(examples, 'englishTextFragments', {
+            const finding = {
                 examId,
                 file: normalizePath(filePath),
                 qNo: question.qNo,
                 location,
                 line: findLine(filePath, fragment),
                 text: fragment.replace(/\s+/g, ' ').slice(0, 120),
-            });
+            };
+            addExample(examples, 'englishTextFragments', finding);
+            addBlockingFinding(blockingFindings, 'englishTextFragments', finding);
         }
 
         for (const section of sections(question)) {
             const children = childItems(section);
             if (children.length > 0 && directAnswer(section)) {
                 fileStats.parentDirectWithChildren++;
-                addExample(examples, 'parentDirectWithChildren', {
+                const finding = {
                     examId,
                     file: normalizePath(filePath),
                     qNo: question.qNo,
                     subQNo: section.subQNo || section.label || '',
                     line: findLine(filePath, section.text),
                     text: text(section.text).replace(/\s+/g, ' ').slice(0, 120),
-                });
+                };
+                addExample(examples, 'parentDirectWithChildren', finding);
+                addBlockingFinding(blockingFindings, 'parentDirectWithChildren', finding);
                 if (!hasText(section.answer) && !hasText(section.modelAnswer)) {
                     fileStats.explanationOnlyParentWithChildren++;
                 }
@@ -301,26 +365,30 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
 
                 if (!answerFieldKeys.some((key) => hasText(item.holder?.[key]))) {
                     fileStats.answerMissing++;
-                    addExample(examples, 'answerMissing', {
+                    const finding = {
                         examId,
                         file: normalizePath(filePath),
                         qNo: question.qNo,
                         subQNo: item.label,
                         line: findLine(filePath, promptText),
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
-                    });
+                    };
+                    addExample(examples, 'answerMissing', finding);
+                    addBlockingFinding(blockingFindings, 'answerMissing', finding);
                 }
 
                 if (!explanationFieldKeys.some((key) => hasText(item.holder?.[key]))) {
                     fileStats.explanationMissing++;
-                    addExample(examples, 'explanationMissing', {
+                    const finding = {
                         examId,
                         file: normalizePath(filePath),
                         qNo: question.qNo,
                         subQNo: item.label,
                         line: findLine(filePath, promptText),
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
-                    });
+                    };
+                    addExample(examples, 'explanationMissing', finding);
+                    addBlockingFinding(blockingFindings, 'explanationMissing', finding);
                 }
 
                 if (refs.length > 0) {
@@ -340,7 +408,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                     const missingRefs = refs.filter((ref) => !refVariants(ref).some((variant) => contextText.includes(variant)));
                     if (missingRefs.length > 0) {
                         fileStats.underlineRefMissing++;
-                        addExample(examples, 'underlineRefMissing', {
+                        const finding = {
                             examId,
                             file: normalizePath(filePath),
                             qNo: question.qNo,
@@ -348,13 +416,15 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                             line: findLine(filePath, promptText),
                             refs: missingRefs,
                             text: promptText.replace(/\s+/g, ' ').slice(0, 120),
-                        });
+                        };
+                        addExample(examples, 'underlineRefMissing', finding);
+                        addBlockingFinding(blockingFindings, 'underlineRefMissing', finding);
                     }
                 }
 
                 if (limits.length > 1) {
                     fileStats.multipleLimits++;
-                    addExample(examples, 'multipleLimits', {
+                    const finding = {
                         examId,
                         file: normalizePath(filePath),
                         qNo: question.qNo,
@@ -362,21 +432,25 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                         line: findLine(filePath, promptText),
                         limits,
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
-                    });
+                    };
+                    addExample(examples, 'multipleLimits', finding);
+                    addBlockingFinding(blockingFindings, 'multipleLimits', finding);
                 }
 
                 if (symbolAnswer) {
                     fileStats.symbolAnswers++;
                     if (choices.length === 0) {
                         fileStats.symbolNoStructuralChoices++;
-                        addExample(examples, 'symbolNoStructuralChoices', {
+                        const finding = {
                             examId,
                             file: normalizePath(filePath),
                             qNo: question.qNo,
                             subQNo: item.label,
                             line: findLine(filePath, promptText),
                             text: promptText.replace(/\s+/g, ' ').slice(0, 120),
-                        });
+                        };
+                        addExample(examples, 'symbolNoStructuralChoices', finding);
+                        addBlockingFinding(blockingFindings, 'symbolNoStructuralChoices', finding);
                     }
                     if (!inlineChoiceBodyPattern.test(promptText)) {
                         fileStats.symbolNoInlineChoiceBody++;
@@ -390,7 +464,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
 
                 if (broadPromptPattern.test(promptText.trim()) && limits.length === 0) {
                     fileStats.broadPromptNoLimit++;
-                    addExample(examples, 'broadPromptNoLimit', {
+                    const finding = {
                         examId,
                         file: normalizePath(filePath),
                         qNo: question.qNo,
@@ -398,7 +472,9 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                         source: item.source,
                         line: findLine(filePath, promptText),
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
-                    });
+                    };
+                    addExample(examples, 'broadPromptNoLimit', finding);
+                    addBlockingFinding(blockingFindings, 'broadPromptNoLimit', finding);
                 }
 
                 if (
@@ -432,7 +508,32 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
     addStats(bySuffix.get(`${category}-${suffix}`), fileStats);
 }
 
-const missingTargetCategories = defaultTargetCategories.filter((category) => !categoryExamCounts.has(category));
+const expectedTargetCategories = (includeCategories ? [...includeCategories] : defaultTargetCategories)
+    .filter((category) => defaultTargetCategories.includes(category))
+    .filter((category) => !excludeCategories.has(category));
+const missingTargetCategories = expectedTargetCategories.filter((category) => !categoryExamCounts.has(category));
+for (const category of missingTargetCategories) {
+    addBlockingFinding(blockingFindings, 'missingTargetCategory', { category });
+}
+
+const defaultAllowlistPath = path.join(repoRoot, 'scripts', 'audit-afternoon-data-quality.allowlist.json');
+const allowlistPath = allowlistArg ? resolveRepoPath(allowlistArg) : fs.existsSync(defaultAllowlistPath) ? defaultAllowlistPath : null;
+const allowlistEntries = readAllowlist(allowlistPath);
+const allowlistedBlockingFindings = blockingFindings.filter((finding) => allowlistEntries.some((entry) => isAllowlisted(finding, entry)));
+const unapprovedBlockingFindings = blockingFindings.filter((finding) => !allowlistEntries.some((entry) => isAllowlisted(finding, entry)));
+const allFindingCount = total.underlineNoEvidence
+    + total.answerMissing
+    + total.explanationMissing
+    + total.underlineRefMissing
+    + total.explanationOnlyParentWithChildren
+    + total.multipleLimits
+    + total.symbolNoStructuralChoices
+    + total.sharedBroadChoiceGroup
+    + total.broadPromptNoLimit
+    + total.shortAnswerNoLimit
+    + total.englishTextFragments
+    + missingTargetCategories.length;
+
 const result = {
     status: 'AFTERNOON_DATA_QUALITY_AUDIT_COMPLETE',
     scope: {
@@ -440,6 +541,18 @@ const result = {
         includedCategories: includeCategories ? [...includeCategories] : 'all',
         excludedCategories: [...excludeCategories],
         missingTargetCategories,
+    },
+    findingCount: {
+        all: allFindingCount,
+        blocking: blockingFindings.length,
+        allowlistedBlocking: allowlistedBlockingFindings.length,
+        unapprovedBlocking: unapprovedBlockingFindings.length,
+        failMode,
+    },
+    blocking: {
+        rules: blockingFindingRules,
+        allowlist: allowlistPath ? normalizePath(allowlistPath) : null,
+        unapprovedFindings: unapprovedBlockingFindings,
     },
     total,
     byCategory: Object.fromEntries([...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b))),
@@ -454,6 +567,8 @@ if (jsonOutput) {
     console.log(`status=${result.status}`);
     console.log(`files=${total.files} mainQuestions=${total.mainQuestions} answerFields=${total.answerFields}`);
     console.log(`missingTargetCategories=${missingTargetCategories.join(',') || 'none'}`);
+    console.log(`findings=${allFindingCount} blocking=${blockingFindings.length} unapprovedBlocking=${unapprovedBlockingFindings.length} failMode=${failMode}`);
+    console.log(`allowlist=${allowlistPath ? normalizePath(allowlistPath) : 'none'}`);
     console.log('');
     console.log('| Category | Files | Main | Fields | Answer missing | Explanation missing | Underline refs | No underline evidence | Ref missing | Parent+children | Explanation-only parent | Multiple limits | Symbol no choices | Broad no limit | Short no limit | English fragments |');
     console.log('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
@@ -470,19 +585,10 @@ if (jsonOutput) {
     }
 }
 
-const findingCount = total.underlineNoEvidence
-    + total.answerMissing
-    + total.explanationMissing
-    + total.underlineRefMissing
-    + total.explanationOnlyParentWithChildren
-    + total.multipleLimits
-    + total.symbolNoStructuralChoices
-    + total.sharedBroadChoiceGroup
-    + total.broadPromptNoLimit
-    + total.shortAnswerNoLimit
-    + total.englishTextFragments
-    + missingTargetCategories.length;
-
-if (failOnFindings && findingCount > 0) {
+const failingFindingCount = failMode === 'all' ? allFindingCount : failMode === 'blocking' ? unapprovedBlockingFindings.length : 0;
+if (failingFindingCount > 0) {
+    if (!jsonOutput) {
+        console.error(`afternoon data quality audit failed: failMode=${failMode} findings=${failingFindingCount}`);
+    }
     process.exit(1);
 }

--- a/scripts/audit-afternoon-data-quality.mjs
+++ b/scripts/audit-afternoon-data-quality.mjs
@@ -93,10 +93,7 @@ function readAllowlist(filePath) {
             console.error(`invalid allowlist entry in ${normalizePath(filePath)}: rule and reason are required`);
             process.exit(1);
         }
-        const hasStableScope = entry.rule === 'missingTargetCategory'
-            ? hasAllowlistValue(entry.category)
-            : hasAllowlistValue(entry.examId) || hasAllowlistValue(entry.file);
-        if (!hasStableScope) {
+        if (!hasAllowlistScope(entry)) {
             const requiredScope = entry.rule === 'missingTargetCategory' ? 'category' : 'examId or file';
             console.error(`invalid allowlist entry in ${normalizePath(filePath)}: ${requiredScope} is required for ${entry.rule}`);
             process.exit(1);
@@ -144,6 +141,12 @@ function hasText(value) {
 
 function hasAllowlistValue(value) {
     return value !== undefined && value !== null && String(value).trim().length > 0;
+}
+
+function hasAllowlistScope(entry) {
+    return entry?.rule === 'missingTargetCategory'
+        ? hasAllowlistValue(entry.category)
+        : hasAllowlistValue(entry?.examId) || hasAllowlistValue(entry?.file);
 }
 
 function childItems(section) {
@@ -261,8 +264,19 @@ function addExample(examples, key, value) {
     if (examples[key].length < 8) examples[key].push(value);
 }
 
-function addBlockingFinding(findings, rule, value) {
-    findings.push({ rule, ...value });
+function addBlockingFinding(rule, value) {
+    const finding = { rule, ...value };
+    blockingFindingCount++;
+
+    if (allowlistEntries.some((entry) => isAllowlisted(finding, entry))) {
+        allowlistedBlockingFindingCount++;
+        return;
+    }
+
+    unapprovedBlockingFindingCount++;
+    if (unapprovedBlockingFindings.length < maxBlockingFindingsInOutput) {
+        unapprovedBlockingFindings.push(finding);
+    }
 }
 
 function getOfficialSource(...objects) {
@@ -307,7 +321,8 @@ function valuesMatch(expected, actual) {
 }
 
 function isAllowlisted(finding, entry) {
-    return valuesMatch(entry.rule, finding.rule)
+    return hasAllowlistScope(entry)
+        && valuesMatch(entry.rule, finding.rule)
         && valuesMatch(entry.examId, finding.examId)
         && valuesMatch(entry.file, finding.file)
         && valuesMatch(entry.category, finding.category)
@@ -346,9 +361,15 @@ if (!fs.existsSync(questionsRoot)) {
 const byCategory = new Map();
 const bySuffix = new Map();
 const examples = {};
-const blockingFindings = [];
+const defaultAllowlistPath = path.join(repoRoot, 'scripts', 'audit-afternoon-data-quality.allowlist.json');
+const allowlistPath = allowlistArg ? resolveRepoPath(allowlistArg) : fs.existsSync(defaultAllowlistPath) ? defaultAllowlistPath : null;
+const allowlistEntries = readAllowlist(allowlistPath);
+const unapprovedBlockingFindings = [];
 const officialSourceFindings = [];
 const categoryExamCounts = new Map();
+let blockingFindingCount = 0;
+let allowlistedBlockingFindingCount = 0;
+let unapprovedBlockingFindingCount = 0;
 let total = makeStats();
 
 function addStats(target, delta) {
@@ -395,7 +416,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                 text: fragment.replace(/\s+/g, ' ').slice(0, 120),
             };
             addExample(examples, 'englishTextFragments', finding);
-            addBlockingFinding(blockingFindings, 'englishTextFragments', finding);
+            addBlockingFinding('englishTextFragments', finding);
         }
 
         for (const section of sections(question)) {
@@ -411,7 +432,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                     text: text(section.text).replace(/\s+/g, ' ').slice(0, 120),
                 };
                 addExample(examples, 'parentDirectWithChildren', finding);
-                addBlockingFinding(blockingFindings, 'parentDirectWithChildren', finding);
+                addBlockingFinding('parentDirectWithChildren', finding);
                 if (!hasText(section.answer) && !hasText(section.modelAnswer)) {
                     fileStats.explanationOnlyParentWithChildren++;
                 }
@@ -469,7 +490,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
                     };
                     addExample(examples, 'answerMissing', finding);
-                    addBlockingFinding(blockingFindings, 'answerMissing', finding);
+                    addBlockingFinding('answerMissing', finding);
                 }
 
                 if (!explanationFieldKeys.some((key) => hasText(item.holder?.[key]))) {
@@ -483,7 +504,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
                     };
                     addExample(examples, 'explanationMissing', finding);
-                    addBlockingFinding(blockingFindings, 'explanationMissing', finding);
+                    addBlockingFinding('explanationMissing', finding);
                 }
 
                 if (refs.length > 0) {
@@ -513,7 +534,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                             text: promptText.replace(/\s+/g, ' ').slice(0, 120),
                         };
                         addExample(examples, 'underlineRefMissing', finding);
-                        addBlockingFinding(blockingFindings, 'underlineRefMissing', finding);
+                        addBlockingFinding('underlineRefMissing', finding);
                     }
                 }
 
@@ -529,7 +550,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
                     };
                     addExample(examples, 'multipleLimits', finding);
-                    addBlockingFinding(blockingFindings, 'multipleLimits', finding);
+                    addBlockingFinding('multipleLimits', finding);
                 }
 
                 if (symbolAnswer) {
@@ -545,7 +566,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                             text: promptText.replace(/\s+/g, ' ').slice(0, 120),
                         };
                         addExample(examples, 'symbolNoStructuralChoices', finding);
-                        addBlockingFinding(blockingFindings, 'symbolNoStructuralChoices', finding);
+                        addBlockingFinding('symbolNoStructuralChoices', finding);
                     }
                     if (!inlineChoiceBodyPattern.test(promptText)) {
                         fileStats.symbolNoInlineChoiceBody++;
@@ -569,7 +590,7 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                         text: promptText.replace(/\s+/g, ' ').slice(0, 120),
                     };
                     addExample(examples, 'broadPromptNoLimit', finding);
-                    addBlockingFinding(blockingFindings, 'broadPromptNoLimit', finding);
+                    addBlockingFinding('broadPromptNoLimit', finding);
                 }
 
                 if (
@@ -608,14 +629,9 @@ const expectedTargetCategories = (includeCategories ? [...includeCategories] : d
     .filter((category) => !excludeCategories.has(category));
 const missingTargetCategories = expectedTargetCategories.filter((category) => !categoryExamCounts.has(category));
 for (const category of missingTargetCategories) {
-    addBlockingFinding(blockingFindings, 'missingTargetCategory', { category });
+    addBlockingFinding('missingTargetCategory', { category });
 }
 
-const defaultAllowlistPath = path.join(repoRoot, 'scripts', 'audit-afternoon-data-quality.allowlist.json');
-const allowlistPath = allowlistArg ? resolveRepoPath(allowlistArg) : fs.existsSync(defaultAllowlistPath) ? defaultAllowlistPath : null;
-const allowlistEntries = readAllowlist(allowlistPath);
-const allowlistedBlockingFindings = blockingFindings.filter((finding) => allowlistEntries.some((entry) => isAllowlisted(finding, entry)));
-const unapprovedBlockingFindings = blockingFindings.filter((finding) => !allowlistEntries.some((entry) => isAllowlisted(finding, entry)));
 const officialSourceOutputLimit = sourceReportMode === 'full' ? officialSourceFindings.length : maxOfficialSourceItemsInOutput;
 const officialSourceOutputItems = sourceReportMode === 'off' ? [] : officialSourceFindings.slice(0, officialSourceOutputLimit);
 const allFindingCount = total.underlineNoEvidence
@@ -641,17 +657,17 @@ const result = {
     },
     findingCount: {
         all: allFindingCount,
-        blocking: blockingFindings.length,
-        allowlistedBlocking: allowlistedBlockingFindings.length,
-        unapprovedBlocking: unapprovedBlockingFindings.length,
+        blocking: blockingFindingCount,
+        allowlistedBlocking: allowlistedBlockingFindingCount,
+        unapprovedBlocking: unapprovedBlockingFindingCount,
         failMode,
     },
     blocking: {
         rules: blockingFindingRules,
         allowlist: allowlistPath ? normalizePath(allowlistPath) : null,
         unapprovedFindingLimit: maxBlockingFindingsInOutput,
-        unapprovedFindingsTruncated: Math.max(0, unapprovedBlockingFindings.length - maxBlockingFindingsInOutput),
-        unapprovedFindings: unapprovedBlockingFindings.slice(0, maxBlockingFindingsInOutput),
+        unapprovedFindingsTruncated: Math.max(0, unapprovedBlockingFindingCount - unapprovedBlockingFindings.length),
+        unapprovedFindings: unapprovedBlockingFindings,
     },
     officialSource: {
         requiredFields: officialSourceRequiredFields,
@@ -676,7 +692,7 @@ if (jsonOutput) {
     console.log(`status=${result.status}`);
     console.log(`files=${total.files} mainQuestions=${total.mainQuestions} answerFields=${total.answerFields}`);
     console.log(`missingTargetCategories=${missingTargetCategories.join(',') || 'none'}`);
-    console.log(`findings=${allFindingCount} blocking=${blockingFindings.length} unapprovedBlocking=${unapprovedBlockingFindings.length} failMode=${failMode}`);
+    console.log(`findings=${allFindingCount} blocking=${blockingFindingCount} unapprovedBlocking=${unapprovedBlockingFindingCount} failMode=${failMode}`);
     console.log(`officialSource verified=${total.officialSourceVerified}/${total.officialSourceItems} missing=${total.officialSourceMissing} incomplete=${total.officialSourceIncomplete} sourceReport=${sourceReportMode}`);
     console.log(`allowlist=${allowlistPath ? normalizePath(allowlistPath) : 'none'}`);
     console.log('');
@@ -695,7 +711,7 @@ if (jsonOutput) {
     }
 }
 
-const failingFindingCount = failMode === 'all' ? allFindingCount : failMode === 'blocking' ? unapprovedBlockingFindings.length : 0;
+const failingFindingCount = failMode === 'all' ? allFindingCount : failMode === 'blocking' ? unapprovedBlockingFindingCount : 0;
 if (failingFindingCount > 0) {
     if (!jsonOutput) {
         console.error(`afternoon data quality audit failed: failMode=${failMode} findings=${failingFindingCount}`);

--- a/scripts/audit-afternoon-data-quality.mjs
+++ b/scripts/audit-afternoon-data-quality.mjs
@@ -20,6 +20,9 @@ const choiceKeys = ['choices', 'options', 'answerChoices'];
 const answerFieldKeys = ['answer', 'modelAnswer', 'correctOption', 'correctAnswer', 'correct', 'expectedAnswer', 'answerExample', 'sampleAnswer'];
 const explanationFieldKeys = ['explanation', 'commentary', '解説'];
 const maxBlockingFindingsInOutput = 50;
+const maxOfficialSourceItemsInOutput = 50;
+const officialSourceKeys = ['officialSource', 'sourceMetadata'];
+const officialSourceRequiredFields = ['sourceUrl', 'sourcePage/sourcePages', 'verifiedAt', 'verificationMethod'];
 const blockingFindingRules = [
     'answerMissing',
     'explanationMissing',
@@ -49,6 +52,7 @@ const failMode = argValue('fail-on') || (failOnBlocking ? 'blocking' : failOnFin
 const categoriesArg = argValue('categories');
 const excludeArg = argValue('exclude');
 const allowlistArg = argValue('allowlist');
+const sourceReportMode = argValue('source-report') || 'summary';
 const includeCategories = categoriesArg
     ? new Set(categoriesArg.split(',').map((value) => value.trim()).filter(Boolean))
     : null;
@@ -56,6 +60,11 @@ const excludeCategories = new Set((excludeArg || '').split(',').map((value) => v
 
 if (!['none', 'all', 'blocking'].includes(failMode)) {
     console.error(`invalid --fail-on value: ${failMode} (expected: none, all, blocking)`);
+    process.exit(1);
+}
+
+if (!['summary', 'full', 'off'].includes(sourceReportMode)) {
+    console.error(`invalid --source-report value: ${sourceReportMode} (expected: summary, full, off)`);
     process.exit(1);
 }
 
@@ -240,6 +249,10 @@ function makeStats() {
         broadPromptNoLimit: 0,
         shortAnswerNoLimit: 0,
         englishTextFragments: 0,
+        officialSourceItems: 0,
+        officialSourceVerified: 0,
+        officialSourceMissing: 0,
+        officialSourceIncomplete: 0,
     };
 }
 
@@ -250,6 +263,41 @@ function addExample(examples, key, value) {
 
 function addBlockingFinding(findings, rule, value) {
     findings.push({ rule, ...value });
+}
+
+function getOfficialSource(...objects) {
+    for (const object of objects) {
+        if (!object || typeof object !== 'object' || Array.isArray(object)) continue;
+        for (const key of officialSourceKeys) {
+            const source = object[key];
+            if (source && typeof source === 'object' && !Array.isArray(source)) return source;
+        }
+        if (
+            hasText(object.sourceUrl)
+            || hasAllowlistValue(object.sourcePage)
+            || (Array.isArray(object.sourcePages) && object.sourcePages.length > 0)
+            || hasText(object.verifiedAt)
+            || hasText(object.verificationMethod)
+        ) {
+            return object;
+        }
+    }
+    return null;
+}
+
+function hasSourcePage(source) {
+    return hasAllowlistValue(source?.sourcePage)
+        || (Array.isArray(source?.sourcePages) && source.sourcePages.some((page) => hasAllowlistValue(page)));
+}
+
+function missingOfficialSourceFields(source) {
+    if (!source) return officialSourceRequiredFields;
+    const missing = [];
+    if (!hasText(source.sourceUrl)) missing.push('sourceUrl');
+    if (!hasSourcePage(source)) missing.push('sourcePage/sourcePages');
+    if (!hasText(source.verifiedAt) || Number.isNaN(Date.parse(source.verifiedAt))) missing.push('verifiedAt');
+    if (!hasText(source.verificationMethod)) missing.push('verificationMethod');
+    return missing;
 }
 
 function valuesMatch(expected, actual) {
@@ -299,6 +347,7 @@ const byCategory = new Map();
 const bySuffix = new Map();
 const examples = {};
 const blockingFindings = [];
+const officialSourceFindings = [];
 const categoryExamCounts = new Map();
 let total = makeStats();
 
@@ -375,6 +424,39 @@ for (const dirent of fs.readdirSync(questionsRoot, { withFileTypes: true })) {
                 const refs = getUnderlineRefs(promptText);
                 const symbolAnswer = symbolAnswerPattern.test(promptText);
                 fileStats.answerFields++;
+
+                const officialSource = getOfficialSource(item.holder, section, question);
+                const officialSourceFindingBase = {
+                    examId,
+                    file: normalizePath(filePath),
+                    qNo: question.qNo,
+                    subQNo: item.label,
+                    source: item.source,
+                    line: findLine(filePath, promptText),
+                    text: promptText.replace(/\s+/g, ' ').slice(0, 120),
+                };
+                fileStats.officialSourceItems++;
+                if (!officialSource) {
+                    fileStats.officialSourceMissing++;
+                    const finding = { rule: 'officialSourceMissing', ...officialSourceFindingBase };
+                    addExample(examples, 'officialSourceMissing', finding);
+                    officialSourceFindings.push(finding);
+                } else {
+                    const missingFields = missingOfficialSourceFields(officialSource);
+                    if (missingFields.length > 0) {
+                        fileStats.officialSourceIncomplete++;
+                        const finding = {
+                            rule: 'officialSourceIncomplete',
+                            ...officialSourceFindingBase,
+                            missingFields,
+                            sourceUrl: text(officialSource.sourceUrl),
+                        };
+                        addExample(examples, 'officialSourceIncomplete', finding);
+                        officialSourceFindings.push(finding);
+                    } else {
+                        fileStats.officialSourceVerified++;
+                    }
+                }
 
                 if (!answerFieldKeys.some((key) => hasText(item.holder?.[key]))) {
                     fileStats.answerMissing++;
@@ -534,6 +616,8 @@ const allowlistPath = allowlistArg ? resolveRepoPath(allowlistArg) : fs.existsSy
 const allowlistEntries = readAllowlist(allowlistPath);
 const allowlistedBlockingFindings = blockingFindings.filter((finding) => allowlistEntries.some((entry) => isAllowlisted(finding, entry)));
 const unapprovedBlockingFindings = blockingFindings.filter((finding) => !allowlistEntries.some((entry) => isAllowlisted(finding, entry)));
+const officialSourceOutputLimit = sourceReportMode === 'full' ? officialSourceFindings.length : maxOfficialSourceItemsInOutput;
+const officialSourceOutputItems = sourceReportMode === 'off' ? [] : officialSourceFindings.slice(0, officialSourceOutputLimit);
 const allFindingCount = total.underlineNoEvidence
     + total.answerMissing
     + total.explanationMissing
@@ -569,6 +653,16 @@ const result = {
         unapprovedFindingsTruncated: Math.max(0, unapprovedBlockingFindings.length - maxBlockingFindingsInOutput),
         unapprovedFindings: unapprovedBlockingFindings.slice(0, maxBlockingFindingsInOutput),
     },
+    officialSource: {
+        requiredFields: officialSourceRequiredFields,
+        reportMode: sourceReportMode,
+        unverifiedItemCount: officialSourceFindings.length,
+        unverifiedItemLimit: sourceReportMode === 'full' ? null : maxOfficialSourceItemsInOutput,
+        unverifiedItemsTruncated: sourceReportMode === 'off'
+            ? officialSourceFindings.length
+            : Math.max(0, officialSourceFindings.length - officialSourceOutputItems.length),
+        unverifiedItems: officialSourceOutputItems,
+    },
     total,
     byCategory: Object.fromEntries([...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b))),
     bySuffix: Object.fromEntries([...bySuffix.entries()].sort(([a], [b]) => a.localeCompare(b))),
@@ -583,12 +677,13 @@ if (jsonOutput) {
     console.log(`files=${total.files} mainQuestions=${total.mainQuestions} answerFields=${total.answerFields}`);
     console.log(`missingTargetCategories=${missingTargetCategories.join(',') || 'none'}`);
     console.log(`findings=${allFindingCount} blocking=${blockingFindings.length} unapprovedBlocking=${unapprovedBlockingFindings.length} failMode=${failMode}`);
+    console.log(`officialSource verified=${total.officialSourceVerified}/${total.officialSourceItems} missing=${total.officialSourceMissing} incomplete=${total.officialSourceIncomplete} sourceReport=${sourceReportMode}`);
     console.log(`allowlist=${allowlistPath ? normalizePath(allowlistPath) : 'none'}`);
     console.log('');
-    console.log('| Category | Files | Main | Fields | Answer missing | Explanation missing | Underline refs | No underline evidence | Ref missing | Parent+children | Explanation-only parent | Multiple limits | Symbol no choices | Broad no limit | Short no limit | English fragments |');
-    console.log('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
+    console.log('| Category | Files | Main | Fields | Answer missing | Explanation missing | Underline refs | No underline evidence | Ref missing | Parent+children | Explanation-only parent | Multiple limits | Symbol no choices | Broad no limit | Short no limit | English fragments | Source verified | Source missing | Source incomplete |');
+    console.log('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
     for (const [category, stats] of [...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-        console.log(`| ${category} | ${stats.files} | ${stats.mainQuestions} | ${stats.answerFields} | ${stats.answerMissing} | ${stats.explanationMissing} | ${stats.underlineRefs} | ${stats.underlineNoEvidence} | ${stats.underlineRefMissing} | ${stats.parentDirectWithChildren} | ${stats.explanationOnlyParentWithChildren} | ${stats.multipleLimits} | ${stats.symbolNoStructuralChoices} | ${stats.broadPromptNoLimit} | ${stats.shortAnswerNoLimit} | ${stats.englishTextFragments} |`);
+        console.log(`| ${category} | ${stats.files} | ${stats.mainQuestions} | ${stats.answerFields} | ${stats.answerMissing} | ${stats.explanationMissing} | ${stats.underlineRefs} | ${stats.underlineNoEvidence} | ${stats.underlineRefMissing} | ${stats.parentDirectWithChildren} | ${stats.explanationOnlyParentWithChildren} | ${stats.multipleLimits} | ${stats.symbolNoStructuralChoices} | ${stats.broadPromptNoLimit} | ${stats.shortAnswerNoLimit} | ${stats.englishTextFragments} | ${stats.officialSourceVerified} | ${stats.officialSourceMissing} | ${stats.officialSourceIncomplete} |`);
     }
     console.log('');
     for (const [key, values] of Object.entries(examples)) {

--- a/scripts/audit-afternoon-data-quality.mjs
+++ b/scripts/audit-afternoon-data-quality.mjs
@@ -19,6 +19,7 @@ const underlineEvidencePattern = /<u\b|underline|text-decoration/i;
 const choiceKeys = ['choices', 'options', 'answerChoices'];
 const answerFieldKeys = ['answer', 'modelAnswer', 'correctOption', 'correctAnswer', 'correct', 'expectedAnswer', 'answerExample', 'sampleAnswer'];
 const explanationFieldKeys = ['explanation', 'commentary', '解説'];
+const maxBlockingFindingsInOutput = 50;
 const blockingFindingRules = [
     'answerMissing',
     'explanationMissing',
@@ -83,6 +84,14 @@ function readAllowlist(filePath) {
             console.error(`invalid allowlist entry in ${normalizePath(filePath)}: rule and reason are required`);
             process.exit(1);
         }
+        const hasStableScope = entry.rule === 'missingTargetCategory'
+            ? hasAllowlistValue(entry.category)
+            : hasAllowlistValue(entry.examId) || hasAllowlistValue(entry.file);
+        if (!hasStableScope) {
+            const requiredScope = entry.rule === 'missingTargetCategory' ? 'category' : 'examId or file';
+            console.error(`invalid allowlist entry in ${normalizePath(filePath)}: ${requiredScope} is required for ${entry.rule}`);
+            process.exit(1);
+        }
     }
     return entries;
 }
@@ -122,6 +131,10 @@ function text(value) {
 
 function hasText(value) {
     return text(value).trim().length > 0;
+}
+
+function hasAllowlistValue(value) {
+    return value !== undefined && value !== null && String(value).trim().length > 0;
 }
 
 function childItems(section) {
@@ -552,7 +565,9 @@ const result = {
     blocking: {
         rules: blockingFindingRules,
         allowlist: allowlistPath ? normalizePath(allowlistPath) : null,
-        unapprovedFindings: unapprovedBlockingFindings,
+        unapprovedFindingLimit: maxBlockingFindingsInOutput,
+        unapprovedFindingsTruncated: Math.max(0, unapprovedBlockingFindings.length - maxBlockingFindingsInOutput),
+        unapprovedFindings: unapprovedBlockingFindings.slice(0, maxBlockingFindingsInOutput),
     },
     total,
     byCategory: Object.fromEntries([...byCategory.entries()].sort(([a], [b]) => a.localeCompare(b))),


### PR DESCRIPTION
## 概要

Closes #269
Closes #272

午後問題データ品質監査を Repository Guards の必須ゲートとして追加しました。既存の standalone bundle 同梱確認とは役割を分離し、ローカル JSON の欠落・構造不備を CI で検出します。

quota 待機中に同種課題として #272 も取り込み、公式PDFとの照合証跡を保持できる `officialSource` メタデータ schema と監査レポートを追加しました。

## 変更内容

- `npm run audit:afternoon-data:ci` を追加し、`--json --fail-on=blocking` で CI 向けに実行
- `.github/workflows/repository-guards.yml` に `afternoon-data-quality-audit` ジョブを追加
- `scripts/audit-afternoon-data-quality.mjs` に blocking finding / allowlist / `--fail-on=blocking` を追加
- `packages/shared/src/types/models.ts` に `OfficialSourceMetadataSchema` と任意の `officialSource` を追加
- `npm run audit:afternoon-source` を追加し、公式PDF出典メタデータの未設定・不完全項目を棚卸し可能に変更
- `docs/02_design/05_DataSyncDesign.md` に CI ゲート、失敗条件、例外管理、公式PDF出典メタデータ方針を追記
- main ベースの pre-push を通すため、PR #275 で検証済みの Vitest worker 安定化差分を取り込み
  - batch runner 経由の `test:run`
  - `happy-dom` / worker 数制御
  - Web CosmosClient の動的 import
  - devcontainer からの Cosmos Emulator 接続判定

## 検証

- `npm run audit:afternoon-data:ci`
  - `findingCount.blocking=0`
  - `findingCount.unapprovedBlocking=0`
- `node scripts/audit-afternoon-data-quality.mjs --json --fail-on=blocking --categories=AP`
- `npm run audit:afternoon-source --silent`
  - `officialSource.total=1577`
  - `officialSource.verified=0`
  - `officialSource.missing=1577`
  - `officialSource.incomplete=0`
- `npm run type-check -w packages/shared`
- `node --check scripts/audit-afternoon-data-quality.mjs`
- `node scripts/guard-exam-data-fallback.mjs`
- `pwsh .github/hooks/self-inspect.ps1 -Mode end -FailOnFinding`
- `npm run test:unit`
  - pre-push でも再実行され、64 test file 完了

## E2E テストエビデンス報告書

E2E は未実行です。UI 変更を含まない CI / 監査スクリプト / schema / ドキュメント変更のため、E2E 証跡報告書は作成していません。

## 残リスク

- `underlineNoEvidence`、`shortAnswerNoLimit`、`sharedBroadChoiceGroup` は調査・改善用 finding として JSON に残しますが、現時点の CI blocking には含めていません。
- 公式PDF出典メタデータは既存データ移行のため任意項目として導入し、未設定・不完全項目は棚卸し対象にしています。
- PR #275 と一部のテスト安定化差分が重複します。#275 が先に main へ入った場合、この PR は rebase / conflict 解消が必要になる可能性があります。
