### PR TITLE
fix(dashboard): keep newly created AI study plans visible after migration

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -501,11 +501,11 @@ export async function deleteStudyPlan(id: string): Promise<boolean> {
 export async function migrateLocalStudyPlansToServer(userId: string): Promise<number> {
     if (typeof window === 'undefined') return -1;
     const flagKey = `studyPlans:migratedFor:${userId}`;
-    if (localStorage.getItem(flagKey)) return -1;
 
     const raw = localStorage.getItem('studyPlans');
     if (!raw) {
-        localStorage.setItem(flagKey, new Date().toISOString());
+        if (localStorage.getItem(flagKey) === 'empty') return -1;
+        localStorage.setItem(flagKey, 'empty');
         return 0;
     }
 
@@ -516,7 +516,8 @@ export async function migrateLocalStudyPlansToServer(userId: string): Promise<nu
         return -1;
     }
     if (!Array.isArray(plans) || plans.length === 0) {
-        localStorage.setItem(flagKey, new Date().toISOString());
+        if (localStorage.getItem(flagKey) === 'empty') return -1;
+        localStorage.setItem(flagKey, 'empty');
         return 0;
     }
 
@@ -524,6 +525,8 @@ export async function migrateLocalStudyPlansToServer(userId: string): Promise<nu
     const normalized = plans.map((p) =>
         p.id ? p : { ...p, id: typeof crypto !== 'undefined' ? crypto.randomUUID() : `legacy-${Date.now()}` },
     );
+    const signature = getStudyPlanMigrationSignature(normalized);
+    if (localStorage.getItem(flagKey) === signature) return -1;
 
     try {
         const res = await fetch(`${API_BASE}/study-plan`, {
@@ -533,10 +536,14 @@ export async function migrateLocalStudyPlansToServer(userId: string): Promise<nu
         });
         if (!res.ok) throw new Error(`migrate POST failed: ${res.status}`);
         const data = await res.json();
-        localStorage.setItem(flagKey, new Date().toISOString());
+        localStorage.setItem(flagKey, signature);
         return typeof data?.count === 'number' ? data.count : normalized.length;
     } catch (e) {
         console.warn('migrateLocalStudyPlansToServer failed:', e);
         return -1;
     }
+}
+
+function getStudyPlanMigrationSignature(plans: StudyPlan[]): string {
+    return JSON.stringify([...plans].sort((a, b) => a.id.localeCompare(b.id)));
 }

--- a/docs/02_design/12_DashboardAndLearningHistoryDesign.md
+++ b/docs/02_design/12_DashboardAndLearningHistoryDesign.md
@@ -259,6 +259,7 @@ sequenceDiagram
 2. なければ旧形式 `studyPlan` を移行する
 3. `monthlyGoals` が欠落しているプランには `createDefaultMonthlyGoals()` を自動付与する
 4. もっとも近い将来の試験日を持つ計画をアクティブ計画とする
+5. 認証済みユーザーは `studyPlans` を `/api/study-plan` へ best-effort で同期する。移行スキップ判定は単純な実行済みフラグではなく、localStorage 内の計画セット署名で行い、初回空状態でフラグが立った後に作成された未同期計画も再移行対象にする。
 
 ---
 
@@ -268,7 +269,8 @@ sequenceDiagram
 
 - 学習記録は Cosmos DB を正本とする
 - 履歴画面では `LearningSessions` を優先し、`LearningRecords` はフォールバックとする
-- 学習計画とゲーミフィケーション状態は現状 localStorage に残る
+- 学習計画は Cosmos DB の `StudyPlan` を正本とし、localStorage の `studyPlans` はゲスト利用・初回移行・オフラインフォールバック用のキャッシュとして扱う
+- ゲーミフィケーション状態は現状 localStorage に残る
 
 ### 11.2 ゲストユーザー
 


### PR DESCRIPTION
Revives the still-valid fix from closed PR #259 (rebased on current main; the unrelated `.github/hooks/self-inspect.ps1` change was dropped).

## Problem
`migrateLocalStudyPlansToServer` permanently set the `migrated` flag, so newly created AI study plans disappeared from the dashboard after a local→server migration.

## Fix
Use a content signature for the migration flag so re-migration is allowed when local plans change; empty state is marked separately.

CI on this PR validates build/test against current main.