### PR TITLE
feat(mobile): 午前解説を Markdown 描画に対応（#286 一次対応）

### DIFF
--- a/apps/mobile/app/exam/[examId]/question/[qNo].tsx
+++ b/apps/mobile/app/exam/[examId]/question/[qNo].tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
+import Markdown from 'react-native-markdown-display';
 import { Mobile } from '@ipa-lab/shared';
 import { useAuthStore } from '../../../../src/store/auth-store';
 import { useExamSessionStore } from '../../../../src/store/exam-session-store';
@@ -224,7 +225,9 @@ export default function QuestionScreen() {
                             {isCorrect ? '✓ 正解' : '✗ 不正解'}
                         </Text>
                         {question.explanation ? (
-                            <Text style={styles.explanation}>{question.explanation}</Text>
+                            <Markdown style={markdownStyles}>
+                                {question.explanation}
+                            </Markdown>
                         ) : null}
                     </View>
                 )}
@@ -324,7 +327,6 @@ const styles = StyleSheet.create({
     resultLabel: { fontSize: 16, fontWeight: '700', marginBottom: 8 },
     correct: { color: '#34D399' },
     wrong: { color: '#F87171' },
-    explanation: { fontSize: 13, color: '#CBD5E0', lineHeight: 20 },
     footer: {
         padding: 16,
         borderTopWidth: 1,
@@ -343,3 +345,48 @@ const styles = StyleSheet.create({
     errorText: { color: '#F87171', fontSize: 14, marginBottom: 16 },
     linkText: { color: '#0070F3', fontSize: 14 },
 });
+
+/**
+ * 解説の Markdown 描画スタイル（ダークテーマ）。
+ * 注: LaTeX 数式（$...$）は本コンポーネントでは未対応で生表示のまま。完全対応は issue #286 で追う。
+ */
+const markdownStyles = {
+    body: { color: '#CBD5E0', fontSize: 13, lineHeight: 20 },
+    strong: { fontWeight: '700' as const, color: '#FFFFFF' },
+    em: { fontStyle: 'italic' as const },
+    heading1: { color: '#FFFFFF', fontWeight: '700' as const, fontSize: 18, marginTop: 10, marginBottom: 6 },
+    heading2: { color: '#FFFFFF', fontWeight: '700' as const, fontSize: 16, marginTop: 10, marginBottom: 6 },
+    heading3: { color: '#FFFFFF', fontWeight: '700' as const, fontSize: 14, marginTop: 8, marginBottom: 4 },
+    bullet_list: { marginVertical: 4 },
+    ordered_list: { marginVertical: 4 },
+    list_item: { marginVertical: 2 },
+    code_inline: {
+        backgroundColor: '#1A202C',
+        color: '#E2E8F0',
+        fontFamily: 'monospace',
+        paddingHorizontal: 4,
+        borderRadius: 4,
+    },
+    fence: {
+        backgroundColor: '#1A202C',
+        color: '#E2E8F0',
+        fontFamily: 'monospace',
+        padding: 10,
+        borderRadius: 6,
+    },
+    code_block: {
+        backgroundColor: '#1A202C',
+        color: '#E2E8F0',
+        fontFamily: 'monospace',
+        padding: 10,
+        borderRadius: 6,
+    },
+    link: { color: '#0070F3' },
+    blockquote: {
+        backgroundColor: '#111827',
+        borderLeftColor: '#0070F3',
+        borderLeftWidth: 3,
+        paddingHorizontal: 10,
+    },
+    hr: { backgroundColor: '#1A202C', height: 1 },
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,7 @@
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
     "react-native": "0.76.9",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "zod": "^3.24.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,6 +210,7 @@
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
         "react-native": "0.76.9",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
         "zod": "^3.24.1",
@@ -14331,6 +14332,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -15257,6 +15267,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -15264,6 +15283,17 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -23370,6 +23400,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -23677,6 +23716,37 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
@@ -28919,6 +28989,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -32522,6 +32598,12 @@
         }
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -33113,6 +33195,15 @@
         }
       }
     },
+    "node_modules/react-native-fit-image": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz",
+      "integrity": "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==",
+      "license": "Beerware",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-helmet-async": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-native-helmet-async/-/react-native-helmet-async-2.0.4.tgz",
@@ -33137,6 +33228,22 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-markdown-display": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz",
+      "integrity": "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-fit-image": "^1.5.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-native": ">=0.50.4"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
@@ -33155,6 +33262,22 @@
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.12.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.12.5.tgz",
+      "integrity": "sha512-INOKPom4dFyzkbxbkuQNfeRG9/iYnyRDzrDkJeyvSWgJAW2IDdJkWFJBS2v0RxIL4gqLgHkiIZDOfiLaNnw83Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
       },
       "peerDependencies": {
         "react": "*",
@@ -36723,6 +36846,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.4",


### PR DESCRIPTION
## 概要
午前問題の**解説**を plain `<Text>` から `react-native-markdown-display` に置き換え、Markdown（`**太字**`・見出し・リスト等）をダークテーマ配色で描画するようにした。

## 背景
Pixel 実機検証（PR #282 の午前フロー確認）で、解説が Markdown / LaTeX を生のまま表示していることを発見（issue #286）。本 PR はそのうち **Markdown 部分を先行対応**する一次対応。

## 変更点
- `apps/mobile/app/exam/[examId]/question/[qNo].tsx`：解説描画を `<Markdown>`（ダークテーマ style）に置換。未使用となった `explanation` スタイルを削除。
- `react-native-markdown-display@^7.0.2` を追加（**JS のみ・ネイティブ再ビルド不要**）。

## 未対応（別 issue）
- **LaTeX 数式（`$...$`）は本 PR では未対応で生表示のまま。** 数式描画は WebView+KaTeX を要するため **issue #286** で別途対応する。

## 検証
- `tsc --noEmit`：**0 エラー**
- Metro バンドル：**成功**（~9MB、`react-native-markdown-display` 解決確認）
- 実機目視：Pixel の USB 接続が不安定なため、再接続後に補足予定（Markdown 太字・見出しの描画確認）

## ブランチ運用
モバイルアプリ一式が #282（`docs/android-play-design-consistency`）側にあり `main` 未マージのため、本 PR は **#282 にスタック**。#282 マージ後に main へリベース/リターゲット想定。

Refs #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)